### PR TITLE
fix: s3 presigned url 발급 기능 수정

### DIFF
--- a/src/main/generated/LinkerBell/campus_market_spring/dto/QItemSearchResponseDto.java
+++ b/src/main/generated/LinkerBell/campus_market_spring/dto/QItemSearchResponseDto.java
@@ -13,8 +13,8 @@ public class QItemSearchResponseDto extends ConstructorExpression<ItemSearchResp
 
     private static final long serialVersionUID = -1184577670L;
 
-    public QItemSearchResponseDto(com.querydsl.core.types.Expression<Long> itemId, com.querydsl.core.types.Expression<Long> userId, com.querydsl.core.types.Expression<String> nickname, com.querydsl.core.types.Expression<String> thumbnail, com.querydsl.core.types.Expression<String> title, com.querydsl.core.types.Expression<Integer> price, com.querydsl.core.types.Expression<Integer> chatCount, com.querydsl.core.types.Expression<Integer> likeCount, com.querydsl.core.types.Expression<LinkerBell.campus_market_spring.domain.ItemStatus> itemStatus) {
-        super(ItemSearchResponseDto.class, new Class<?>[]{long.class, long.class, String.class, String.class, String.class, int.class, int.class, int.class, LinkerBell.campus_market_spring.domain.ItemStatus.class}, itemId, userId, nickname, thumbnail, title, price, chatCount, likeCount, itemStatus);
+    public QItemSearchResponseDto(com.querydsl.core.types.Expression<Long> itemId, com.querydsl.core.types.Expression<Long> userId, com.querydsl.core.types.Expression<String> nickname, com.querydsl.core.types.Expression<String> thumbnail, com.querydsl.core.types.Expression<String> title, com.querydsl.core.types.Expression<Integer> price, com.querydsl.core.types.Expression<Integer> chatCount, com.querydsl.core.types.Expression<Integer> likeCount, com.querydsl.core.types.Expression<LinkerBell.campus_market_spring.domain.ItemStatus> itemStatus, com.querydsl.core.types.Expression<Boolean> isLiked) {
+        super(ItemSearchResponseDto.class, new Class<?>[]{long.class, long.class, String.class, String.class, String.class, int.class, int.class, int.class, LinkerBell.campus_market_spring.domain.ItemStatus.class, boolean.class}, itemId, userId, nickname, thumbnail, title, price, chatCount, likeCount, itemStatus, isLiked);
     }
 
 }

--- a/src/main/java/LinkerBell/campus_market_spring/service/S3Service.java
+++ b/src/main/java/LinkerBell/campus_market_spring/service/S3Service.java
@@ -34,7 +34,7 @@ public class S3Service {
         String encodedTime = getEncodedTime(now).substring(0, 6);
 
         fileName = fileName.trim()
-            .replaceAll("\\s", "-")
+            .replaceAll("\\s+", "-")
             .replaceAll("_", "-");
 
         String keyName = String.format("%s/%s%s%s",

--- a/src/main/java/LinkerBell/campus_market_spring/service/S3Service.java
+++ b/src/main/java/LinkerBell/campus_market_spring/service/S3Service.java
@@ -33,6 +33,10 @@ public class S3Service {
         String date = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         String encodedTime = getEncodedTime(now).substring(0, 6);
 
+        fileName = fileName.trim()
+            .replaceAll("\\s", "-")
+            .replaceAll("_", "-");
+
         String keyName = String.format("%s/%s%s%s",
             awsProperties.folder(), encodedTime, date, fileName);
 

--- a/src/test/java/LinkerBell/campus_market_spring/service/S3ServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/service/S3ServiceTest.java
@@ -31,7 +31,7 @@ class S3ServiceTest {
     @DisplayName("파일 이름에 공백과 언더바가 포함된 경우 presigned put url 발급 테스트")
     public void getPresignedPutUrlWithWhiteSpaceAndUnderscoreTest() {
         // given
-        String fileName = "test_file and white space";
+        String fileName = "test_file and   white space";
         // when
         S3ResponseDto responseDto = s3Service.createPreSignedPutUrl(fileName);
         // then

--- a/src/test/java/LinkerBell/campus_market_spring/service/S3ServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/service/S3ServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import LinkerBell.campus_market_spring.dto.S3ResponseDto;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -24,6 +25,20 @@ class S3ServiceTest {
         assertThat(responseDto).isNotNull();
         assertThat(responseDto.getPresignedUrl()).contains(fileName);
         assertThat(responseDto.getS3url()).contains(fileName);
+    }
+
+    @Test
+    @DisplayName("파일 이름에 공백과 언더바가 포함된 경우 presigned put url 발급 테스트")
+    public void getPresignedPutUrlWithWhiteSpaceAndUnderscoreTest() {
+        // given
+        String fileName = "test_file and white space";
+        // when
+        S3ResponseDto responseDto = s3Service.createPreSignedPutUrl(fileName);
+        // then
+        assertThat(responseDto).isNotNull();
+        assertThat(responseDto.getS3url()).doesNotContainAnyWhitespaces();
+        assertThat(responseDto.getS3url()).doesNotContain("_");
+        assertThat(responseDto.getS3url()).contains("test-file-and-white-space");
     }
 
 //    @Test


### PR DESCRIPTION
s3 url 발급 시 파일 이름에 공백이나 언더바가 포함된 경우 제거하는 코드
추가