### PR TITLE
feat: admin 로그인 기능 추가

### DIFF
--- a/src/main/java/LinkerBell/campus_market_spring/admin/controller/AdminController.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/controller/AdminController.java
@@ -3,8 +3,11 @@ package LinkerBell.campus_market_spring.admin.controller;
 import LinkerBell.campus_market_spring.admin.dto.AdminLoginRequestDto;
 import LinkerBell.campus_market_spring.admin.service.AdminService;
 import LinkerBell.campus_market_spring.dto.AuthResponseDto;
+import LinkerBell.campus_market_spring.dto.AuthUserDto;
+import LinkerBell.campus_market_spring.global.auth.Login;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,5 +24,10 @@ public class AdminController {
     public ResponseEntity<AuthResponseDto> adminLogin(@RequestBody AdminLoginRequestDto requestDto) {
         AuthResponseDto authResponseDto = adminService.adminLogin(requestDto.idToken());
         return ResponseEntity.ok(authResponseDto);
+    }
+
+    @GetMapping("/test")
+    public ResponseEntity<String> test(@Login AuthUserDto user) {
+        return ResponseEntity.ok("Hello Admin! " + user.getLoginEmail());
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/controller/AdminController.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/controller/AdminController.java
@@ -1,0 +1,25 @@
+package LinkerBell.campus_market_spring.admin.controller;
+
+import LinkerBell.campus_market_spring.admin.dto.AdminLoginRequestDto;
+import LinkerBell.campus_market_spring.admin.service.AdminService;
+import LinkerBell.campus_market_spring.dto.AuthResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/api/v1")
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthResponseDto> adminLogin(@RequestBody AdminLoginRequestDto requestDto) {
+        AuthResponseDto authResponseDto = adminService.adminLogin(requestDto.idToken());
+        return ResponseEntity.ok(authResponseDto);
+    }
+}

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminLoginRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminLoginRequestDto.java
@@ -1,0 +1,5 @@
+package LinkerBell.campus_market_spring.admin.dto;
+
+public record AdminLoginRequestDto(String idToken) {
+
+}

--- a/src/main/java/LinkerBell/campus_market_spring/admin/service/AdminService.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/service/AdminService.java
@@ -1,0 +1,44 @@
+package LinkerBell.campus_market_spring.admin.service;
+
+import LinkerBell.campus_market_spring.domain.Role;
+import LinkerBell.campus_market_spring.domain.User;
+import LinkerBell.campus_market_spring.dto.AuthResponseDto;
+import LinkerBell.campus_market_spring.global.error.ErrorCode;
+import LinkerBell.campus_market_spring.global.error.exception.CustomException;
+import LinkerBell.campus_market_spring.global.jwt.JwtUtils;
+import LinkerBell.campus_market_spring.repository.UserRepository;
+import LinkerBell.campus_market_spring.service.GoogleAuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminService {
+
+    private final GoogleAuthService googleAuthService;
+    private final UserRepository userRepository;
+    private final JwtUtils jwtUtils;
+
+    public AuthResponseDto adminLogin(String idToken) {
+        String email = googleAuthService.getEmailWithVerifyIdToken(idToken);
+
+        User user = userRepository.findByLoginEmail(email).orElseThrow(() ->
+            new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getRole() != Role.ADMIN) {
+            throw new CustomException(ErrorCode.NOT_ADMINISTRATOR);
+        }
+
+        String accessToken = jwtUtils.generateAccessToken(user.getUserId(), user.getLoginEmail(), user.getRole());
+        String refreshToken = jwtUtils.generateRefreshToken(user.getUserId(), user.getLoginEmail(), user.getRole());
+
+        user.setRefreshToken(refreshToken);
+        userRepository.save(user);
+
+        return AuthResponseDto.builder()
+            .accessToken(accessToken)
+            .refreshToken(refreshToken).build();
+    }
+}

--- a/src/main/java/LinkerBell/campus_market_spring/controller/AuthController.java
+++ b/src/main/java/LinkerBell/campus_market_spring/controller/AuthController.java
@@ -30,7 +30,7 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<AuthResponseDto> login(@RequestBody AuthRequestDto authRequestDto) {
         AuthResponseDto authResponseDto =
-            authService.googleLogin(authRequestDto.getIdToken(), authRequestDto.getFirebaseToken());
+            authService.userLogin(authRequestDto.getIdToken(), authRequestDto.getFirebaseToken());
         return ResponseEntity.ok(authResponseDto);
     }
 

--- a/src/main/java/LinkerBell/campus_market_spring/domain/Role.java
+++ b/src/main/java/LinkerBell/campus_market_spring/domain/Role.java
@@ -6,6 +6,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Getter
 public enum Role {
-    GUEST("ROLE_GUEST"),USER("ROLE_USER"),ADMIN("ROLE_ADMIN");
+    USER("ROLE_USER"),ADMIN("ROLE_ADMIN");
     private final String key;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/global/config/SecurityConfig.java
+++ b/src/main/java/LinkerBell/campus_market_spring/global/config/SecurityConfig.java
@@ -27,8 +27,9 @@ public class SecurityConfig {
             .sessionManagement(AbstractHttpConfigurer::disable)
             .authorizeHttpRequests((auth) -> {
                 auth
-                    .requestMatchers("/api/v1/auth/**", "/api/v1/auth/*").permitAll()
+                    .requestMatchers("/api/v1/auth/login", "/admin/api/v1/login").permitAll()
                     .requestMatchers("/ws/**").permitAll()
+                    .requestMatchers("/admin/**").hasRole("ADMIN")
                     .anyRequest().authenticated();
             })
             .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/LinkerBell/campus_market_spring/global/error/ErrorCode.java
+++ b/src/main/java/LinkerBell/campus_market_spring/global/error/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, 4040, "잘못된 메시지 conentType입니다."),
     DUPLICATE_CHATROOM(HttpStatus.BAD_REQUEST, 4041, "같은 판매자와 아이템을 가진 채팅방이 이미 있습니다."),
     EMPTY_ITEM_THUMBNAIL(HttpStatus.BAD_REQUEST, 4042, "빈 썸네일은 등록할 수 없습니다."),
+    NOT_ADMINISTRATOR(HttpStatus.FORBIDDEN, 4043, "관리자 권한이 없는 사용자입니다."),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 내부 오류입니다."),
 

--- a/src/main/java/LinkerBell/campus_market_spring/global/jwt/JwtFilter.java
+++ b/src/main/java/LinkerBell/campus_market_spring/global/jwt/JwtFilter.java
@@ -44,8 +44,8 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
         String path = request.getRequestURI();
-        return path.startsWith("/api/v1/auth/login") || path.startsWith("/api/v1/auth/refresh")
-            || path.startsWith("/ws");
+        return path.startsWith("/api/v1/auth/login") || path.startsWith("/ws")
+            || path.startsWith("/admin/api/v1/login");
 
     }
 

--- a/src/main/java/LinkerBell/campus_market_spring/global/jwt/JwtFilter.java
+++ b/src/main/java/LinkerBell/campus_market_spring/global/jwt/JwtFilter.java
@@ -29,6 +29,9 @@ public class JwtFilter extends OncePerRequestFilter {
         FilterChain filterChain) throws ServletException, IOException {
         try {
             String token = jwtUtils.resolveToken(request);
+            if (token == null) {
+                token = jwtUtils.resolveRefreshToken(request);
+            }
             if (jwtUtils.validateToken(token)) {
                 Authentication authentication = jwtUtils.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/src/main/java/LinkerBell/campus_market_spring/service/AuthService.java
+++ b/src/main/java/LinkerBell/campus_market_spring/service/AuthService.java
@@ -2,30 +2,17 @@ package LinkerBell.campus_market_spring.service;
 
 import LinkerBell.campus_market_spring.domain.Role;
 import LinkerBell.campus_market_spring.domain.User;
-import LinkerBell.campus_market_spring.domain.UserFcmToken;
 import LinkerBell.campus_market_spring.dto.AuthResponseDto;
 import LinkerBell.campus_market_spring.dto.AuthUserDto;
 import LinkerBell.campus_market_spring.global.error.ErrorCode;
 import LinkerBell.campus_market_spring.global.error.exception.CustomException;
 import LinkerBell.campus_market_spring.global.jwt.JwtUtils;
-import LinkerBell.campus_market_spring.repository.UserFcmTokenRepository;
 import LinkerBell.campus_market_spring.repository.UserRepository;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
-import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
-import com.google.api.client.json.gson.GsonFactory;
 import jakarta.servlet.http.HttpServletRequest;
-import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.util.Collections;
 
 @Slf4j
 @Service
@@ -33,23 +20,13 @@ import java.util.Collections;
 @Transactional
 public class AuthService {
 
-    @Value("${google.client}")
-    private String GOOGLE_CLIENT_ID;
     private final UserRepository userRepository;
     private final JwtUtils jwtUtils;
-    private final UserFcmTokenRepository userFcmTokenRepository;
+    private final FcmService fcmService;
+    private final GoogleAuthService googleAuthService;
 
-    public AuthResponseDto googleLogin(String googleToken, String firebaseToken) {
-        log.info("google Token: " + googleToken);
-        log.info("firebase Token: " + firebaseToken);
-        GoogleIdToken idToken = getGoogleIdToken(googleToken);
-
-        if (idToken == null) {
-            log.error("idToken is null");
-            throw new CustomException(ErrorCode.INVALID_GOOGLE_TOKEN);
-        }
-
-        String email = getEmailFromGoogleIdToken(idToken);
+    public AuthResponseDto userLogin(String googleToken, String firebaseToken) {
+        String email = googleAuthService.getEmailWithVerifyIdToken(googleToken);
 
         User user = userRepository.findByLoginEmail(email)
             .orElseGet(() -> createNewUser(email));
@@ -62,64 +39,20 @@ public class AuthService {
         user.setRefreshToken(refreshToken);
         userRepository.save(user);
 
-        saveUserFcmToken(firebaseToken, user);
+        fcmService.saveUserFcmToken(firebaseToken, user);
 
         return AuthResponseDto.builder()
             .accessToken(accessToken)
             .refreshToken(refreshToken).build();
     }
 
-    private void saveUserFcmToken(String firebaseToken, User user) {
-        userFcmTokenRepository.findByFcmToken(firebaseToken).ifPresentOrElse(userFcmToken -> {
-                log.info("already exist.");
-                userFcmToken.setLastModifiedDate(LocalDateTime.now());
-                userFcmTokenRepository.save(userFcmToken);
-            },
-            () -> {
-                log.info("not exist.");
-                UserFcmToken userFcmToken = UserFcmToken.builder().fcmToken(firebaseToken)
-                    .user(user).build();
-                userFcmTokenRepository.save(userFcmToken);
-            });
-    }
-
     private User createNewUser(String email) {
         User newUser = User.builder()
             .loginEmail(email)
-            .role(Role.GUEST)
+            .role(Role.USER)
             .build();
 
         return userRepository.save(newUser);
-    }
-
-    private String getEmailFromGoogleIdToken(GoogleIdToken idToken) {
-        GoogleIdToken.Payload payload = idToken.getPayload();
-
-        boolean emailVerified = payload.getEmailVerified();
-        if (!emailVerified) {
-            throw new CustomException(ErrorCode.NOT_VERIFIED_EMAIL);
-        }
-
-        return payload.getEmail();
-    }
-
-    private GoogleIdToken getGoogleIdToken(String googleToken) {
-        GoogleIdToken idToken = null;
-        try {
-            GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(
-                GoogleNetHttpTransport.newTrustedTransport(),
-                GsonFactory.getDefaultInstance())
-                .setAudience(Collections.singletonList(GOOGLE_CLIENT_ID))
-                .build();
-            idToken = verifier.verify(googleToken);
-
-        } catch (GeneralSecurityException | IOException e) {
-            throw new CustomException(ErrorCode.UNVERIFIED_GOOGLE_TOKEN);
-        } catch (IllegalArgumentException e) {
-            log.error("IllegalArgumentException");
-            throw new CustomException(ErrorCode.INVALID_GOOGLE_TOKEN);
-        }
-        return idToken;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/LinkerBell/campus_market_spring/service/FcmService.java
+++ b/src/main/java/LinkerBell/campus_market_spring/service/FcmService.java
@@ -2,8 +2,11 @@ package LinkerBell.campus_market_spring.service;
 
 import LinkerBell.campus_market_spring.domain.Item;
 import LinkerBell.campus_market_spring.domain.Keyword;
+import LinkerBell.campus_market_spring.domain.User;
+import LinkerBell.campus_market_spring.domain.UserFcmToken;
 import LinkerBell.campus_market_spring.dto.FcmMessageDto;
 import LinkerBell.campus_market_spring.repository.UserFcmTokenRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,6 +50,20 @@ public class FcmService {
             .body("등록하신 " + sendingKeyword.getKeywordName() + " 키워드에 대한 아이템이 등록되었어요.")
             .deeplinkUrl(deeplinkKeywordUrl + savedItem.getItemId())
             .build();
+    }
+
+    public void saveUserFcmToken(String firebaseToken, User user) {
+        userFcmTokenRepository.findByFcmToken(firebaseToken).ifPresentOrElse(userFcmToken -> {
+                log.info("already exist.");
+                userFcmToken.setLastModifiedDate(LocalDateTime.now());
+                userFcmTokenRepository.save(userFcmToken);
+            },
+            () -> {
+                log.info("not exist.");
+                UserFcmToken userFcmToken = UserFcmToken.builder().fcmToken(firebaseToken)
+                    .user(user).build();
+                userFcmTokenRepository.save(userFcmToken);
+            });
     }
 
 }

--- a/src/main/java/LinkerBell/campus_market_spring/service/GoogleAuthService.java
+++ b/src/main/java/LinkerBell/campus_market_spring/service/GoogleAuthService.java
@@ -1,0 +1,65 @@
+package LinkerBell.campus_market_spring.service;
+
+import LinkerBell.campus_market_spring.global.error.ErrorCode;
+import LinkerBell.campus_market_spring.global.error.exception.CustomException;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
+import com.google.api.client.googleapis.auth.oauth2.GoogleIdTokenVerifier;
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
+import com.google.api.client.json.gson.GsonFactory;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleAuthService {
+
+    @Value("${google.client}")
+    private String GOOGLE_CLIENT_ID;
+
+    public String getEmailWithVerifyIdToken(String idToken) {
+        GoogleIdToken googleIdToken = getGoogleIdToken(idToken);
+
+        if (idToken == null) {
+            log.error("idToken is null");
+            throw new CustomException(ErrorCode.INVALID_GOOGLE_TOKEN);
+        }
+
+        return getEmailFromGoogleIdToken(googleIdToken);
+    }
+
+    private GoogleIdToken getGoogleIdToken(String googleToken) {
+        GoogleIdToken idToken = null;
+        try {
+            GoogleIdTokenVerifier verifier = new GoogleIdTokenVerifier.Builder(
+                GoogleNetHttpTransport.newTrustedTransport(),
+                GsonFactory.getDefaultInstance())
+                .setAudience(Collections.singletonList(GOOGLE_CLIENT_ID))
+                .build();
+            idToken = verifier.verify(googleToken);
+
+        } catch (GeneralSecurityException | IOException e) {
+            throw new CustomException(ErrorCode.UNVERIFIED_GOOGLE_TOKEN);
+        } catch (IllegalArgumentException e) {
+            log.error("IllegalArgumentException");
+            throw new CustomException(ErrorCode.INVALID_GOOGLE_TOKEN);
+        }
+        return idToken;
+    }
+
+    private String getEmailFromGoogleIdToken(GoogleIdToken idToken) {
+        GoogleIdToken.Payload payload = idToken.getPayload();
+
+        boolean emailVerified = payload.getEmailVerified();
+        if (!emailVerified) {
+            throw new CustomException(ErrorCode.NOT_VERIFIED_EMAIL);
+        }
+
+        return payload.getEmail();
+    }
+}

--- a/src/test/java/LinkerBell/campus_market_spring/admin/service/AdminServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/admin/service/AdminServiceTest.java
@@ -1,0 +1,86 @@
+package LinkerBell.campus_market_spring.admin.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import LinkerBell.campus_market_spring.domain.Role;
+import LinkerBell.campus_market_spring.domain.User;
+import LinkerBell.campus_market_spring.dto.AuthResponseDto;
+import LinkerBell.campus_market_spring.global.error.ErrorCode;
+import LinkerBell.campus_market_spring.global.error.exception.CustomException;
+import LinkerBell.campus_market_spring.global.jwt.JwtUtils;
+import LinkerBell.campus_market_spring.repository.UserRepository;
+import LinkerBell.campus_market_spring.service.GoogleAuthService;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @InjectMocks
+    private AdminService adminService;
+
+    @Mock
+    private GoogleAuthService googleAuthService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private JwtUtils jwtUtils;
+
+    @Test
+    @DisplayName("관리자 로그인 테스트")
+    public void adminLoginTest() {
+        // given
+        User admin = createAdmin();
+        String accessToken = "testAccessToken";
+        String refreshToken = "testRefreshToken";
+        given(googleAuthService.getEmailWithVerifyIdToken(anyString()))
+            .willReturn("test@example.com");
+        given(userRepository.findByLoginEmail("test@example.com")).willReturn(Optional.ofNullable(admin));
+        given(jwtUtils.generateAccessToken(anyLong(), anyString(), any(Role.class)))
+            .willReturn(accessToken);
+        given(jwtUtils.generateRefreshToken(anyLong(), anyString(), any(Role.class)))
+            .willReturn(refreshToken);
+        // when
+        AuthResponseDto responseDto = adminService.adminLogin("testIdToken");
+        // then
+        assertThat(responseDto).isNotNull();
+        assertThat(responseDto.getAccessToken()).isEqualTo(accessToken);
+        assertThat(responseDto.getRefreshToken()).isEqualTo(refreshToken);
+    }
+
+    @Test
+    @DisplayName("관리자가 아닌 사용자 로그인 테스트")
+    public void adminLoginWithoutAdminRoleTest() {
+        // given
+        User user = createUser();
+        given(googleAuthService.getEmailWithVerifyIdToken(anyString()))
+            .willReturn("test@example.com");
+        given(userRepository.findByLoginEmail("test@example.com")).willReturn(Optional.ofNullable(user));
+        // when & then
+        assertThatThrownBy(() -> adminService.adminLogin("testIdToken"))
+            .isInstanceOf(CustomException.class)
+            .hasMessage(ErrorCode.NOT_ADMINISTRATOR.getMessage());
+    }
+
+    private User createAdmin() {
+        return User.builder()
+            .loginEmail("test@example.com")
+            .role(Role.ADMIN)
+            .userId(1L).build();
+    }
+
+    private User createUser() {
+        return User.builder()
+            .loginEmail("test@example.com")
+            .role(Role.USER)
+            .userId(100L).build();
+    }
+}

--- a/src/test/java/LinkerBell/campus_market_spring/controller/AuthControllerTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/controller/AuthControllerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -25,8 +24,6 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.test.web.client.RequestMatcher;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
@@ -63,7 +60,7 @@ class AuthControllerTest {
         RequestDto requestDto = new RequestDto("googleToken", "firebaseToken");
         AuthResponseDto authResponseDto = AuthResponseDto.builder().accessToken("testAccessToken")
             .refreshToken("testRefreshToken").build();
-        given(authService.googleLogin(requestDto.getIdToken(), requestDto.getFirebaseToken()))
+        given(authService.userLogin(requestDto.getIdToken(), requestDto.getFirebaseToken()))
             .willReturn(authResponseDto);
 
         // when
@@ -77,7 +74,7 @@ class AuthControllerTest {
             .andExpect(status().isOk()).andDo(print()).andReturn();
 
         then(authService).should(times(1))
-            .googleLogin(assertArg(g-> assertThat(g).isEqualTo(requestDto.getIdToken())),
+            .userLogin(assertArg(g-> assertThat(g).isEqualTo(requestDto.getIdToken())),
                 assertArg(f -> assertThat(f).isEqualTo(requestDto.getFirebaseToken())));
     }
 

--- a/src/test/java/LinkerBell/campus_market_spring/repository/LikeRepositoryTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/repository/LikeRepositoryTest.java
@@ -205,7 +205,7 @@ class LikeRepositoryTest {
     private User createUser(Long id) {
         return User.builder()
             .userId(id)
-            .role(Role.GUEST)
+            .role(Role.USER)
             .loginEmail("user" + id + "@example.com")
             .schoolEmail("user" + id + "@ajou.ac.kr")
             .nickname("i'm user" + id)

--- a/src/test/java/LinkerBell/campus_market_spring/repository/UserRepositoryTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/repository/UserRepositoryTest.java
@@ -105,7 +105,7 @@ class UserRepositoryTest {
     private User createUser() {
         return User.builder()
                 .loginEmail("abc@gmail.com")
-                .role(Role.GUEST)
+                .role(Role.USER)
                 .build();
     }
 
@@ -119,7 +119,7 @@ class UserRepositoryTest {
     private User createSchoolUser() {
         return User.builder()
             .loginEmail("abc@gmail.com")
-            .role(Role.GUEST)
+            .role(Role.USER)
             .schoolEmail("test@school.com")
             .build();
     }

--- a/src/test/java/LinkerBell/campus_market_spring/service/AuthServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/service/AuthServiceTest.java
@@ -57,7 +57,7 @@ class AuthServiceTest {
 
         assertThat(userDto.getUserId()).isEqualTo(1L);
         assertThat(userDto.getLoginEmail()).isEqualTo("abc@gmail.com");
-        assertThat(userDto.getRole()).isEqualTo(Role.GUEST);
+        assertThat(userDto.getRole()).isEqualTo(Role.USER);
     }
 
     @Test
@@ -96,7 +96,7 @@ class AuthServiceTest {
         return User.builder()
             .userId(1L)
             .loginEmail("abc@gmail.com")
-            .role(Role.GUEST)
+            .role(Role.USER)
             .build();
     }
 }

--- a/src/test/java/LinkerBell/campus_market_spring/service/LikeServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/service/LikeServiceTest.java
@@ -146,7 +146,7 @@ class LikeServiceTest {
     private User createUser(Long id) {
         return User.builder()
             .userId(id)
-            .role(Role.GUEST)
+            .role(Role.USER)
             .loginEmail("user" + id + "@example.com")
             .schoolEmail("user" + id + "@ajou.ac.kr")
             .nickname("i'm user" + id)

--- a/src/test/java/LinkerBell/campus_market_spring/service/ProfileServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/service/ProfileServiceTest.java
@@ -232,7 +232,7 @@ class ProfileServiceTest {
             .profileImage("old_url")
             .schoolEmail("abc@ajou.ac.kr")
             .rating(0.0)
-            .role(Role.GUEST).build();
+            .role(Role.USER).build();
     }
 
     private Campus createDiffCampus() {
@@ -246,7 +246,7 @@ class ProfileServiceTest {
     private User createOther() {
         return User.builder().userId(11L).schoolEmail("test2.example2.com")
             .profileImage("other's profile image").rating(5.2).nickname("I'm other")
-            .role(Role.GUEST).build();
+            .role(Role.USER).build();
     }
 
 }


### PR DESCRIPTION
admin package 추가
관리자 로그인 기능 추가
관리자 로그인도 jwtFilter에서 제외
관리자 api의 경우 ADMIN 권한 제한 추가
Role에서 사용하지 않은 GUEST 삭제
google id token 검증 로직을 GoogleAuthService로 분리
fcmToken 저장 로직도 FcmService로 분리