### PR TITLE
feat: 상품, 사용자 신고 기능 구현

### DIFF
--- a/src/main/java/LinkerBell/campus_market_spring/controller/ReportController.java
+++ b/src/main/java/LinkerBell/campus_market_spring/controller/ReportController.java
@@ -22,7 +22,8 @@ public class ReportController {
     @PostMapping("/items/{itemId}/report")
     public ResponseEntity<?> reportItem(@Login AuthUserDto user, @PathVariable("itemId") Long itemId,
         @RequestBody ItemReportRequestDto requestDto) {
-        reportService.reportItem(user.getUserId(), itemId, requestDto.getDescription());
+        reportService.reportItem(user.getUserId(), itemId,
+            requestDto.getDescription(), requestDto.getCategory());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/controller/ReportController.java
+++ b/src/main/java/LinkerBell/campus_market_spring/controller/ReportController.java
@@ -1,0 +1,28 @@
+package LinkerBell.campus_market_spring.controller;
+
+import LinkerBell.campus_market_spring.dto.AuthUserDto;
+import LinkerBell.campus_market_spring.dto.ItemReportRequestDto;
+import LinkerBell.campus_market_spring.global.auth.Login;
+import LinkerBell.campus_market_spring.service.ReportService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping("/items/{itemId}/report")
+    public ResponseEntity<?> reportItem(@Login AuthUserDto user, @PathVariable("itemId") Long itemId,
+        @RequestBody ItemReportRequestDto requestDto) {
+        reportService.reportItem(user.getUserId(), itemId, requestDto.getDescription());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/LinkerBell/campus_market_spring/controller/ReportController.java
+++ b/src/main/java/LinkerBell/campus_market_spring/controller/ReportController.java
@@ -2,8 +2,10 @@ package LinkerBell.campus_market_spring.controller;
 
 import LinkerBell.campus_market_spring.dto.AuthUserDto;
 import LinkerBell.campus_market_spring.dto.ItemReportRequestDto;
+import LinkerBell.campus_market_spring.dto.UserReportRequestDto;
 import LinkerBell.campus_market_spring.global.auth.Login;
 import LinkerBell.campus_market_spring.service.ReportService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,8 +23,16 @@ public class ReportController {
 
     @PostMapping("/items/{itemId}/report")
     public ResponseEntity<?> reportItem(@Login AuthUserDto user, @PathVariable("itemId") Long itemId,
-        @RequestBody ItemReportRequestDto requestDto) {
+        @Valid @RequestBody ItemReportRequestDto requestDto) {
         reportService.reportItem(user.getUserId(), itemId,
+            requestDto.getDescription(), requestDto.getCategory());
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/users/{userId}/report")
+    public ResponseEntity<?> reportUser(@Login AuthUserDto user, @PathVariable("userId") Long targetId,
+        @Valid @RequestBody UserReportRequestDto requestDto) {
+        reportService.reportUser(user.getUserId(), targetId,
             requestDto.getDescription(), requestDto.getCategory());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/LinkerBell/campus_market_spring/domain/ItemReport.java
+++ b/src/main/java/LinkerBell/campus_market_spring/domain/ItemReport.java
@@ -2,6 +2,11 @@ package LinkerBell.campus_market_spring.domain;
 
 import static jakarta.persistence.FetchType.LAZY;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,6 +18,11 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 
 @Entity
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ItemReport extends BaseEntity {
 
     @Id

--- a/src/main/java/LinkerBell/campus_market_spring/domain/ItemReportCategory.java
+++ b/src/main/java/LinkerBell/campus_market_spring/domain/ItemReportCategory.java
@@ -1,5 +1,17 @@
 package LinkerBell.campus_market_spring.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum ItemReportCategory {
-    OTHER
+    PROHIBITED_ITEM("거래 금지 물품"),
+    NOT_SECONDHAND_POST("중고거래 게시글이 아님"),
+    COMMERCIAL_SELLER("전문판매업자"),
+    DISPUTE_DURING_TRANSACTION("거래 중 분쟁"),
+    FRAUD("사기"),
+    OTHER("기타");
+
+    private final String description;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/domain/UserReport.java
+++ b/src/main/java/LinkerBell/campus_market_spring/domain/UserReport.java
@@ -11,8 +11,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
 public class UserReport extends BaseEntity {
 
     @Id

--- a/src/main/java/LinkerBell/campus_market_spring/domain/UserReportCategory.java
+++ b/src/main/java/LinkerBell/campus_market_spring/domain/UserReportCategory.java
@@ -1,5 +1,19 @@
 package LinkerBell.campus_market_spring.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum UserReportCategory {
-    OTHER
+    OTHER("기타"),
+    FRAUD("사기"),
+    DISPUTE_DURING_TRANSACTION("거래 중 분쟁"),
+    RUDE_USER("비매너 사용자"),
+    PROFESSIONAL_SELLER("전문판매업자"),
+    DATING_PURPOSE_CHAT("연애 목적의 대화"),
+    HATE_SPEECH("욕설, 비방, 혐오표현"),
+    INAPPROPRIATE_SEXUAL_BEHAVIOR("부적절한 성적 행위");
+
+    private final String description;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/dto/ItemReportRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/dto/ItemReportRequestDto.java
@@ -1,9 +1,13 @@
 package LinkerBell.campus_market_spring.dto;
 
+import LinkerBell.campus_market_spring.domain.ItemReportCategory;
 import lombok.Getter;
+import lombok.Setter;
 
 @Getter
+@Setter
 public class ItemReportRequestDto {
 
+    private ItemReportCategory category;
     private String description;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/dto/ItemReportRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/dto/ItemReportRequestDto.java
@@ -1,0 +1,9 @@
+package LinkerBell.campus_market_spring.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ItemReportRequestDto {
+
+    private String description;
+}

--- a/src/main/java/LinkerBell/campus_market_spring/dto/ItemReportRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/dto/ItemReportRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,6 +17,6 @@ public class ItemReportRequestDto {
     private ItemReportCategory category;
 
     @NotBlank
-    @Min(2) @Max(1000)
+    @Size(min = 2, max = 1000)
     private String description;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/dto/UserReportRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/dto/UserReportRequestDto.java
@@ -1,6 +1,6 @@
 package LinkerBell.campus_market_spring.dto;
 
-import LinkerBell.campus_market_spring.domain.ItemReportCategory;
+import LinkerBell.campus_market_spring.domain.UserReportCategory;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -10,12 +10,13 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class ItemReportRequestDto {
+public class UserReportRequestDto {
 
     @NotNull
-    private ItemReportCategory category;
+    private UserReportCategory category;
 
     @NotBlank
     @Min(2) @Max(1000)
     private String description;
+
 }

--- a/src/main/java/LinkerBell/campus_market_spring/dto/UserReportRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/dto/UserReportRequestDto.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -16,7 +17,7 @@ public class UserReportRequestDto {
     private UserReportCategory category;
 
     @NotBlank
-    @Min(2) @Max(1000)
+    @Size(min = 2, max = 1000)
     private String description;
 
 }

--- a/src/main/java/LinkerBell/campus_market_spring/global/error/ErrorCode.java
+++ b/src/main/java/LinkerBell/campus_market_spring/global/error/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     DUPLICATE_CHATROOM(HttpStatus.BAD_REQUEST, 4041, "같은 판매자와 아이템을 가진 채팅방이 이미 있습니다."),
     EMPTY_ITEM_THUMBNAIL(HttpStatus.BAD_REQUEST, 4042, "빈 썸네일은 등록할 수 없습니다."),
     NOT_ADMINISTRATOR(HttpStatus.FORBIDDEN, 4043, "관리자 권한이 없는 사용자입니다."),
+    NOT_REPORT_OWN(HttpStatus.BAD_REQUEST, 4044, "자기 자신을 신고할 수 없습니다."),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 내부 오류입니다."),
 

--- a/src/main/java/LinkerBell/campus_market_spring/repository/ItemReportRepository.java
+++ b/src/main/java/LinkerBell/campus_market_spring/repository/ItemReportRepository.java
@@ -1,0 +1,10 @@
+package LinkerBell.campus_market_spring.repository;
+
+import LinkerBell.campus_market_spring.domain.ItemReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ItemReportRepository extends JpaRepository<ItemReport, Long> {
+
+}

--- a/src/main/java/LinkerBell/campus_market_spring/repository/UserReportRepository.java
+++ b/src/main/java/LinkerBell/campus_market_spring/repository/UserReportRepository.java
@@ -1,0 +1,10 @@
+package LinkerBell.campus_market_spring.repository;
+
+import LinkerBell.campus_market_spring.domain.UserReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserReportRepository extends JpaRepository<UserReport, Long> {
+
+}

--- a/src/main/java/LinkerBell/campus_market_spring/service/ReportService.java
+++ b/src/main/java/LinkerBell/campus_market_spring/service/ReportService.java
@@ -38,6 +38,10 @@ public class ReportService {
         Item item = itemRepository.findById(itemId)
             .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
 
+        if (Objects.equals(userId, item.getUser().getUserId())) {
+            throw new CustomException(ErrorCode.NOT_REPORT_OWN);
+        }
+
         validateEqualUniversity(user.getCampus(), item.getCampus());
 
         ItemReport itemReport = ItemReport.builder()

--- a/src/main/java/LinkerBell/campus_market_spring/service/ReportService.java
+++ b/src/main/java/LinkerBell/campus_market_spring/service/ReportService.java
@@ -1,5 +1,6 @@
 package LinkerBell.campus_market_spring.service;
 
+import LinkerBell.campus_market_spring.domain.Campus;
 import LinkerBell.campus_market_spring.domain.Item;
 import LinkerBell.campus_market_spring.domain.ItemReport;
 import LinkerBell.campus_market_spring.domain.ItemReportCategory;
@@ -17,6 +18,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import software.amazon.awssdk.utils.StringUtils;
 
 @Service
 @Slf4j
@@ -36,9 +38,7 @@ public class ReportService {
         Item item = itemRepository.findById(itemId)
             .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
 
-        if (user.getCampus() != item.getUser().getCampus()) {
-            throw new CustomException(ErrorCode.NOT_MATCH_USER_CAMPUS_WITH_ITEM_CAMPUS);
-        }
+        validateEqualUniversity(user.getCampus(), item.getCampus());
 
         ItemReport itemReport = ItemReport.builder()
             .item(item).description(description)
@@ -58,6 +58,8 @@ public class ReportService {
         User target = userRepository.findById(targetId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
+        validateEqualUniversity(user.getCampus(), target.getCampus());
+
         UserReport userReport = UserReport.builder()
             .user(user).target(target)
             .category(category)
@@ -65,5 +67,14 @@ public class ReportService {
             .isCompleted(false).build();
 
         userReportRepository.save(userReport);
+    }
+
+    private void validateEqualUniversity(Campus userCampus, Campus targetCampus) {
+        if (userCampus == null || targetCampus == null) {
+            throw new CustomException(ErrorCode.CAMPUS_NOT_FOUND);
+        }
+        if (!StringUtils.equals(userCampus.getUniversityName(), targetCampus.getUniversityName())) {
+            throw new CustomException(ErrorCode.NOT_MATCH_USER_CAMPUS);
+        }
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/service/ReportService.java
+++ b/src/main/java/LinkerBell/campus_market_spring/service/ReportService.java
@@ -1,0 +1,41 @@
+package LinkerBell.campus_market_spring.service;
+
+import LinkerBell.campus_market_spring.domain.Item;
+import LinkerBell.campus_market_spring.domain.ItemReport;
+import LinkerBell.campus_market_spring.domain.User;
+import LinkerBell.campus_market_spring.global.error.ErrorCode;
+import LinkerBell.campus_market_spring.global.error.exception.CustomException;
+import LinkerBell.campus_market_spring.repository.ItemReportRepository;
+import LinkerBell.campus_market_spring.repository.ItemRepository;
+import LinkerBell.campus_market_spring.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+public class ReportService {
+
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final ItemReportRepository itemReportRepository;
+
+    public void reportItem(Long userId, Long itemId, String description) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Item item = itemRepository.findById(itemId)
+            .orElseThrow(() -> new CustomException(ErrorCode.ITEM_NOT_FOUND));
+
+        if (user.getCampus() != item.getUser().getCampus()) {
+            throw new CustomException(ErrorCode.NOT_MATCH_USER_CAMPUS_WITH_ITEM_CAMPUS);
+        }
+
+        ItemReport itemReport = ItemReport.builder()
+            .item(item).description(description).user(user).build();
+
+        itemReportRepository.save(itemReport);
+    }
+}

--- a/src/main/java/LinkerBell/campus_market_spring/service/ReportService.java
+++ b/src/main/java/LinkerBell/campus_market_spring/service/ReportService.java
@@ -4,12 +4,16 @@ import LinkerBell.campus_market_spring.domain.Item;
 import LinkerBell.campus_market_spring.domain.ItemReport;
 import LinkerBell.campus_market_spring.domain.ItemReportCategory;
 import LinkerBell.campus_market_spring.domain.User;
+import LinkerBell.campus_market_spring.domain.UserReport;
+import LinkerBell.campus_market_spring.domain.UserReportCategory;
 import LinkerBell.campus_market_spring.global.error.ErrorCode;
 import LinkerBell.campus_market_spring.global.error.exception.CustomException;
 import LinkerBell.campus_market_spring.repository.ItemReportRepository;
 import LinkerBell.campus_market_spring.repository.ItemRepository;
+import LinkerBell.campus_market_spring.repository.UserReportRepository;
 import LinkerBell.campus_market_spring.repository.UserRepository;
 import jakarta.transaction.Transactional;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -23,6 +27,7 @@ public class ReportService {
     private final UserRepository userRepository;
     private final ItemRepository itemRepository;
     private final ItemReportRepository itemReportRepository;
+    private final UserReportRepository userReportRepository;
 
     public void reportItem(Long userId, Long itemId, String description,
         ItemReportCategory category) {
@@ -41,5 +46,24 @@ public class ReportService {
             .isCompleted(false).build();
 
         itemReportRepository.save(itemReport);
+    }
+
+    public void reportUser(Long userId, Long targetId, String description,
+        UserReportCategory category) {
+        if (Objects.equals(userId, targetId)) {
+            throw new CustomException(ErrorCode.NOT_REPORT_OWN);
+        }
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        User target = userRepository.findById(targetId)
+            .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        UserReport userReport = UserReport.builder()
+            .user(user).target(target)
+            .category(category)
+            .description(description)
+            .isCompleted(false).build();
+
+        userReportRepository.save(userReport);
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/service/ReportService.java
+++ b/src/main/java/LinkerBell/campus_market_spring/service/ReportService.java
@@ -2,6 +2,7 @@ package LinkerBell.campus_market_spring.service;
 
 import LinkerBell.campus_market_spring.domain.Item;
 import LinkerBell.campus_market_spring.domain.ItemReport;
+import LinkerBell.campus_market_spring.domain.ItemReportCategory;
 import LinkerBell.campus_market_spring.domain.User;
 import LinkerBell.campus_market_spring.global.error.ErrorCode;
 import LinkerBell.campus_market_spring.global.error.exception.CustomException;
@@ -23,7 +24,8 @@ public class ReportService {
     private final ItemRepository itemRepository;
     private final ItemReportRepository itemReportRepository;
 
-    public void reportItem(Long userId, Long itemId, String description) {
+    public void reportItem(Long userId, Long itemId, String description,
+        ItemReportCategory category) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
         Item item = itemRepository.findById(itemId)
@@ -34,7 +36,9 @@ public class ReportService {
         }
 
         ItemReport itemReport = ItemReport.builder()
-            .item(item).description(description).user(user).build();
+            .item(item).description(description)
+            .category(category).user(user)
+            .isCompleted(false).build();
 
         itemReportRepository.save(itemReport);
     }

--- a/src/test/java/LinkerBell/campus_market_spring/controller/ReportControllerTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/controller/ReportControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import LinkerBell.campus_market_spring.controller.AuthControllerTest.MockLoginArgumentResolver;
 import LinkerBell.campus_market_spring.domain.ItemReportCategory;
+import LinkerBell.campus_market_spring.domain.UserReportCategory;
 import LinkerBell.campus_market_spring.global.error.GlobalExceptionHandler;
 import LinkerBell.campus_market_spring.service.ReportService;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +45,7 @@ class ReportControllerTest {
     public void itemReportTest() throws Exception {
         // given
         Long itemId = 1L;
-        String desc = "사기 같아요";
+        String desc = "사기 같아요. 확인해주세요.";
         ItemReportCategory reportCategory = ItemReportCategory.FRAUD;
         String request = String.format("""
             {
@@ -52,6 +53,7 @@ class ReportControllerTest {
                 "category" : "%s"
             }
             """, desc, reportCategory.name());
+
         // when
         mockMvc.perform(post("/api/v1/items/" + itemId + "/report")
             .contentType(MediaType.APPLICATION_JSON)
@@ -60,6 +62,34 @@ class ReportControllerTest {
         // then
         then(reportService).should(times(1)).reportItem(anyLong(), assertArg(id -> {
             assertThat(id).isEqualTo(itemId);
+        }), assertArg(description -> {
+            assertThat(description).isEqualTo(desc);
+        }), assertArg(category -> {
+            assertThat(category).isEqualTo(reportCategory);
+        }));
+    }
+
+    @Test
+    @DisplayName("사용자 신고 테스트")
+    public void userReportTest() throws Exception {
+        // given
+        Long userId = 3L;
+        String desc = "사기 같아요. 확인해주세요.";
+        UserReportCategory reportCategory = UserReportCategory.FRAUD;
+        String request = String.format("""
+            {
+                "description" : "%s",
+                "category" : "%s"
+            }
+            """, desc, reportCategory.name());
+        // when
+        mockMvc.perform(post("/api/v1/users/" + userId + "/report")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(request))
+            .andDo(print());
+        // then
+        then(reportService).should(times(1)).reportUser(anyLong(), assertArg(id -> {
+            assertThat(id).isEqualTo(userId);
         }), assertArg(description -> {
             assertThat(description).isEqualTo(desc);
         }), assertArg(category -> {

--- a/src/test/java/LinkerBell/campus_market_spring/controller/ReportControllerTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/controller/ReportControllerTest.java
@@ -1,0 +1,69 @@
+package LinkerBell.campus_market_spring.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import LinkerBell.campus_market_spring.controller.AuthControllerTest.MockLoginArgumentResolver;
+import LinkerBell.campus_market_spring.domain.ItemReportCategory;
+import LinkerBell.campus_market_spring.global.error.GlobalExceptionHandler;
+import LinkerBell.campus_market_spring.service.ReportService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+@ExtendWith(MockitoExtension.class)
+class ReportControllerTest {
+
+    @InjectMocks
+    private ReportController reportController;
+
+    @Mock
+    private ReportService reportService;
+
+    MockMvc mockMvc;
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(reportController)
+            .setControllerAdvice(GlobalExceptionHandler.class)
+            .setCustomArgumentResolvers(new MockLoginArgumentResolver()).build();
+    }
+
+    @Test
+    @DisplayName("상품 신고 테스트")
+    public void itemReportTest() throws Exception {
+        // given
+        Long itemId = 1L;
+        String desc = "사기 같아요";
+        ItemReportCategory reportCategory = ItemReportCategory.FRAUD;
+        String request = String.format("""
+            {
+                "description" : "%s",
+                "category" : "%s"
+            }
+            """, desc, reportCategory.name());
+        // when
+        mockMvc.perform(post("/api/v1/items/" + itemId + "/report")
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(request))
+            .andExpect(status().isNoContent()).andDo(print());
+        // then
+        then(reportService).should(times(1)).reportItem(anyLong(), assertArg(id -> {
+            assertThat(id).isEqualTo(itemId);
+        }), assertArg(description -> {
+            assertThat(description).isEqualTo(desc);
+        }), assertArg(category -> {
+            assertThat(category).isEqualTo(reportCategory);
+        }));
+    }
+}

--- a/src/test/java/LinkerBell/campus_market_spring/repository/ItemReportRepositoryTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/repository/ItemReportRepositoryTest.java
@@ -1,0 +1,87 @@
+package LinkerBell.campus_market_spring.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import LinkerBell.campus_market_spring.domain.Campus;
+import LinkerBell.campus_market_spring.domain.Item;
+import LinkerBell.campus_market_spring.domain.ItemReport;
+import LinkerBell.campus_market_spring.domain.Role;
+import LinkerBell.campus_market_spring.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ItemReportRepositoryTest {
+
+    @Autowired
+    private ItemReportRepository itemReportRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CampusRepository campusRepository;
+    @Autowired
+    private ItemRepository itemRepository;
+
+    private User user;
+    private User other;
+    private Item item;
+    private Campus campus;
+
+    @BeforeEach
+    public void setUp() {
+        campus = createCampus();
+        campus = campusRepository.save(campus);
+        user = createUser(1L, campus);
+        other = createUser(2L, campus);
+        user = userRepository.save(user);
+        other = userRepository.save(other);
+
+        item = createItem(other);
+        item = itemRepository.save(item);
+    }
+
+    @Test
+    @DisplayName("상품 신고 저장 테스트")
+    public void saveItemReportTest() {
+        // given
+        ItemReport itemReport = ItemReport.builder()
+            .user(user).item(item).description("test reason").build();
+
+        // when
+        ItemReport findItemReport = itemReportRepository.save(itemReport);
+        // then
+        assertThat(findItemReport).isNotNull();
+        assertThat(findItemReport).isEqualTo(itemReport);
+    }
+
+    private Campus createCampus() {
+        return Campus.builder()
+            .campusId(1L)
+            .email("testUniv@example.com")
+            .region("korea")
+            .universityName("testUniv")
+            .build();
+    }
+
+    private User createUser(Long userId, Campus campus) {
+        return User.builder()
+            .userId(userId)
+            .role(Role.USER)
+            .loginEmail("testEmail")
+            .campus(campus)
+            .schoolEmail("testSchool")
+            .nickname("user" + userId).build();
+    }
+
+    private Item createItem(User user) {
+        return Item.builder()
+            .campus(user.getCampus())
+            .user(user)
+            .title("testItem")
+            .description("testItemDescription")
+            .price(10000000).build();
+    }
+}

--- a/src/test/java/LinkerBell/campus_market_spring/repository/ItemReportRepositoryTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/repository/ItemReportRepositoryTest.java
@@ -48,7 +48,7 @@ class ItemReportRepositoryTest {
     public void saveItemReportTest() {
         // given
         ItemReport itemReport = ItemReport.builder()
-            .user(user).item(item).description("test reason").build();
+            .user(user).item(item).description("test reason").isCompleted(false).build();
 
         // when
         ItemReport findItemReport = itemReportRepository.save(itemReport);

--- a/src/test/java/LinkerBell/campus_market_spring/repository/UserReportRepositoryTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/repository/UserReportRepositoryTest.java
@@ -1,0 +1,77 @@
+package LinkerBell.campus_market_spring.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.*;
+
+import LinkerBell.campus_market_spring.domain.Campus;
+import LinkerBell.campus_market_spring.domain.Item;
+import LinkerBell.campus_market_spring.domain.ItemReport;
+import LinkerBell.campus_market_spring.domain.Role;
+import LinkerBell.campus_market_spring.domain.User;
+import LinkerBell.campus_market_spring.domain.UserReport;
+import LinkerBell.campus_market_spring.domain.UserReportCategory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class UserReportRepositoryTest {
+    @Autowired
+    private UserReportRepository userReportRepository;
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private CampusRepository campusRepository;
+
+    private User user;
+    private User other;
+    private Campus campus;
+
+    @BeforeEach
+    public void setUp() {
+        campus = createCampus();
+        campus = campusRepository.save(campus);
+        user = createUser(1L, campus);
+        other = createUser(2L, campus);
+        user = userRepository.save(user);
+        other = userRepository.save(other);
+    }
+
+    @Test
+    @DisplayName("사용자 신고 테스트")
+    public void userReportTest() {
+        // given
+        String description =  UserReportCategory.FRAUD.getDescription();
+        UserReportCategory category = UserReportCategory.FRAUD;
+        UserReport userReport = UserReport.builder()
+            .user(user).target(other).description(description).category(category).build();
+        // when
+        UserReport findUserReportDto = userReportRepository.save(userReport);
+        // then
+        assertThat(findUserReportDto).isNotNull();
+        assertThat(findUserReportDto.getDescription()).isEqualTo(description);
+    }
+
+    private Campus createCampus() {
+        return Campus.builder()
+            .campusId(1L)
+            .email("testUniv@example.com")
+            .region("korea")
+            .universityName("testUniv")
+            .build();
+    }
+
+    private User createUser(Long userId, Campus campus) {
+        return User.builder()
+            .userId(userId)
+            .role(Role.USER)
+            .loginEmail("testEmail")
+            .campus(campus)
+            .schoolEmail("testSchool")
+            .nickname("user" + userId).build();
+    }
+
+
+}

--- a/src/test/java/LinkerBell/campus_market_spring/service/ReportServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/service/ReportServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.*;
 
 import LinkerBell.campus_market_spring.domain.Campus;
 import LinkerBell.campus_market_spring.domain.Item;
+import LinkerBell.campus_market_spring.domain.ItemReportCategory;
 import LinkerBell.campus_market_spring.domain.Role;
 import LinkerBell.campus_market_spring.domain.User;
 import LinkerBell.campus_market_spring.global.error.ErrorCode;
@@ -57,13 +58,15 @@ class ReportServiceTest {
         given(userRepository.findById(anyLong())).willReturn(Optional.ofNullable(user));
         given(itemRepository.findById(anyLong())).willReturn(Optional.ofNullable(item));
         // when
-        reportService.reportItem(user.getUserId(), item.getItemId(), "test reason");
+        reportService.reportItem(user.getUserId(), item.getItemId(), "test reason",
+            ItemReportCategory.PROHIBITED_ITEM);
         // then
         then(itemReportRepository).should(times(1)).save(assertArg(report -> {
             assertThat(report).isNotNull();
             assertThat(report.getItem()).isEqualTo(item);
             assertThat(report.getUser()).isEqualTo(user);
             assertThat(report.getItem().getUser()).isEqualTo(other);
+            assertThat(report.getCategory()).isEqualTo(ItemReportCategory.PROHIBITED_ITEM);
         }));
     }
 
@@ -77,7 +80,8 @@ class ReportServiceTest {
         given(itemRepository.findById(anyLong())).willReturn(Optional.ofNullable(item));
 
         // when & then
-        assertThatThrownBy(() -> reportService.reportItem(user.getUserId(), item.getItemId(), "test reason"))
+        assertThatThrownBy(() -> reportService.reportItem(user.getUserId(), item.getItemId(),
+            "test reason", ItemReportCategory.FRAUD))
             .isInstanceOf(CustomException.class)
             .hasMessageContaining(ErrorCode.NOT_MATCH_USER_CAMPUS_WITH_ITEM_CAMPUS.getMessage());
     }

--- a/src/test/java/LinkerBell/campus_market_spring/service/ReportServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/service/ReportServiceTest.java
@@ -1,0 +1,113 @@
+package LinkerBell.campus_market_spring.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import LinkerBell.campus_market_spring.domain.Campus;
+import LinkerBell.campus_market_spring.domain.Item;
+import LinkerBell.campus_market_spring.domain.Role;
+import LinkerBell.campus_market_spring.domain.User;
+import LinkerBell.campus_market_spring.global.error.ErrorCode;
+import LinkerBell.campus_market_spring.global.error.exception.CustomException;
+import LinkerBell.campus_market_spring.repository.ItemReportRepository;
+import LinkerBell.campus_market_spring.repository.ItemRepository;
+import LinkerBell.campus_market_spring.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @InjectMocks
+    private ReportService reportService;
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private ItemRepository itemRepository;
+    @Mock
+    private ItemReportRepository itemReportRepository;
+
+    private User user;
+    private User other;
+    private Item item;
+    private Campus campus;
+    private Campus otherCampus;
+
+    @BeforeEach
+    public void setUp() {
+        campus = createCampus(1L);
+        otherCampus = createCampus(2L);
+        user = createUser(1L, campus);
+        other = createUser(2L, campus);
+        item = createItem(other);
+    }
+
+    @Test
+    @DisplayName("상품 신고 테스트")
+    public void reportItemTest() {
+        // given
+        given(userRepository.findById(anyLong())).willReturn(Optional.ofNullable(user));
+        given(itemRepository.findById(anyLong())).willReturn(Optional.ofNullable(item));
+        // when
+        reportService.reportItem(user.getUserId(), item.getItemId(), "test reason");
+        // then
+        then(itemReportRepository).should(times(1)).save(assertArg(report -> {
+            assertThat(report).isNotNull();
+            assertThat(report.getItem()).isEqualTo(item);
+            assertThat(report.getUser()).isEqualTo(user);
+            assertThat(report.getItem().getUser()).isEqualTo(other);
+        }));
+    }
+
+    @Test
+    @DisplayName("다른 캠퍼스 상품 신고 에러 테스트")
+    public void reportOtherCampusItemErrorTest() {
+        // given
+        other.setCampus(otherCampus);
+        item.setUser(other);
+        given(userRepository.findById(anyLong())).willReturn(Optional.ofNullable(user));
+        given(itemRepository.findById(anyLong())).willReturn(Optional.ofNullable(item));
+
+        // when & then
+        assertThatThrownBy(() -> reportService.reportItem(user.getUserId(), item.getItemId(), "test reason"))
+            .isInstanceOf(CustomException.class)
+            .hasMessageContaining(ErrorCode.NOT_MATCH_USER_CAMPUS_WITH_ITEM_CAMPUS.getMessage());
+    }
+
+    private Campus createCampus(Long campusId) {
+        return Campus.builder()
+            .campusId(campusId)
+            .email(String.format("testUniv@example%d.com", campusId))
+            .region("korea")
+            .universityName(String.format("testUniv%d", campusId))
+            .build();
+    }
+
+    private User createUser(Long userId, Campus campus) {
+        return User.builder()
+            .userId(userId)
+            .role(Role.USER)
+            .loginEmail("testEmail")
+            .campus(campus)
+            .schoolEmail("testSchool")
+            .nickname("user" + userId).build();
+    }
+
+    private Item createItem(User user) {
+        return Item.builder()
+            .itemId(1L)
+            .campus(user.getCampus())
+            .user(user)
+            .title("testItem")
+            .description("testItemDescription")
+            .price(10000000).build();
+    }
+}

--- a/src/test/java/LinkerBell/campus_market_spring/service/ReportServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/service/ReportServiceTest.java
@@ -92,6 +92,20 @@ class ReportServiceTest {
     }
 
     @Test
+    @DisplayName("자기 자신의 상품 신고 에러 테스트")
+    public void reportOwnItemErrorTest() {
+        // given
+        Item newItem = createItem(user);
+        given(userRepository.findById(anyLong())).willReturn(Optional.ofNullable(user));
+        given(itemRepository.findById(anyLong())).willReturn(Optional.ofNullable(newItem));
+        // when & then
+        assertThatThrownBy(() -> reportService.reportItem(user.getUserId(), newItem.getItemId(),
+            "test reason", ItemReportCategory.FRAUD))
+            .isInstanceOf(CustomException.class)
+            .hasMessageContaining(ErrorCode.NOT_REPORT_OWN.getMessage());
+    }
+
+    @Test
     @DisplayName("사용자 신고 테스트")
     public void reportUserTest() {
         // given


### PR DESCRIPTION
## 변경 사항
- ItemReportCategory 항목 추가
- 상품 신고 정보 db에 저장
- ReportController 추가
- ReportService 추가
- ItemReportRepository 추가
- ItemReportRequestDto 추가
- 테스트 코드 추가
- 사용자 신고 기능 추가
- 사용자 신고  테스트 코드 추가
- validation 추가
- UserReportCategory 항목 추가
- UserReportRepository 추가