### PR TITLE
feat: 관리자용 사용자 신고 처리 기능 구현

### DIFF
--- a/src/main/java/LinkerBell/campus_market_spring/admin/controller/AdminController.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/controller/AdminController.java
@@ -3,6 +3,7 @@ package LinkerBell.campus_market_spring.admin.controller;
 import LinkerBell.campus_market_spring.admin.dto.AdminItemReportRequestDto;
 import LinkerBell.campus_market_spring.admin.dto.AdminItemSearchResponseDto;
 import LinkerBell.campus_market_spring.admin.dto.AdminLoginRequestDto;
+import LinkerBell.campus_market_spring.admin.dto.AdminUserReportRequestDto;
 import LinkerBell.campus_market_spring.admin.dto.ItemReportResponseDto;
 import LinkerBell.campus_market_spring.admin.dto.ItemReportSearchResponseDto;
 import LinkerBell.campus_market_spring.admin.dto.UserReportSearchResponseDto;
@@ -106,5 +107,13 @@ public class AdminController {
         @Valid @RequestBody AdminItemReportRequestDto requestDto) {
         adminService.receiveItemReport(itemReportId, requestDto.isDeleted());
         return ResponseEntity.noContent().build();
+    }
+
+    @PatchMapping("/users/report/{userReportId}")
+    public ResponseEntity<?> receiveUserReport(@PathVariable("userReportId") Long userReportId,
+        @Valid @RequestBody AdminUserReportRequestDto requestDto) {
+        adminService.receiveUserReport(userReportId, requestDto.isSuspended(),
+            requestDto.suspendReason(), requestDto.suspendPeriod());
+       return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminUserReportRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminUserReportRequestDto.java
@@ -1,0 +1,11 @@
+package LinkerBell.campus_market_spring.admin.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AdminUserReportRequestDto(
+    @NotNull Boolean isSuspended,
+    String suspendReason,
+    Integer suspendPeriod
+) {
+
+}

--- a/src/main/java/LinkerBell/campus_market_spring/domain/Blacklist.java
+++ b/src/main/java/LinkerBell/campus_market_spring/domain/Blacklist.java
@@ -10,8 +10,18 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class Blacklist extends BaseEntity {
 
     @Id

--- a/src/main/java/LinkerBell/campus_market_spring/global/error/ErrorCode.java
+++ b/src/main/java/LinkerBell/campus_market_spring/global/error/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     UNVERIFIED_GOOGLE_TOKEN(HttpStatus.UNAUTHORIZED, 4005, "Google idToken이 확인되지 않습니다."),
     NOT_VERIFIED_EMAIL(HttpStatus.UNAUTHORIZED, 4006, "Google email is not verified"),
     JWT_IS_NULL(HttpStatus.UNAUTHORIZED, 4007, "jwt의 값이 null입니다."),
+    BLACKLIST_USER(HttpStatus.FORBIDDEN, 4008, "정지된 사용자입니다."),
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 4011, "사용자가 존재하지 않습니다."),
     ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, 4012, "아이템이 존재하지 않습니다."),
@@ -68,6 +69,7 @@ public enum ErrorCode {
     ITEM_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, 4059 , "해당 상품 신고를 찾을 수 없습니다." ),
     USER_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, 4060 , "해당 사용자 신고를 찾을 수 없습니다." ),
     REQUIRE_DELETE_OR_NOT(HttpStatus.BAD_REQUEST, 4061, "삭제 여부가 필요합니다."),
+    NOT_NULL_USER_REPORT_SUSPENDED_OR_NOT(HttpStatus.BAD_REQUEST, 4062, "사용자 신고의 정지 여부는 비울 수 없습니다."),
 
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버 내부 오류입니다."),
 

--- a/src/main/java/LinkerBell/campus_market_spring/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/LinkerBell/campus_market_spring/global/error/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package LinkerBell.campus_market_spring.global.error;
 
+import LinkerBell.campus_market_spring.admin.dto.AdminUserReportRequestDto;
 import LinkerBell.campus_market_spring.dto.QaRequestDto;
 import LinkerBell.campus_market_spring.admin.dto.AdminItemReportRequestDto;
 import LinkerBell.campus_market_spring.dto.ReviewRequestDto;
@@ -23,8 +24,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handleException(CustomException exception) {
         ErrorCode errorCode = exception.getErrorCode();
-        ErrorResponse errorResponse = new ErrorResponse(errorCode);
-        log.info("Error : " + errorResponse.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(exception.getMessage(), errorCode.getCode());
+        log.error("Error : {}", errorResponse.getMessage());
         return new ResponseEntity<>(errorResponse, errorCode.getHttpStatus());
     }
 
@@ -111,6 +112,14 @@ public class GlobalExceptionHandler {
                 ErrorResponse errorResponse = new ErrorResponse(ErrorCode.REQUIRE_DELETE_OR_NOT);
                 return new ResponseEntity<>(errorResponse,
                     ErrorCode.REQUIRE_DELETE_OR_NOT.getHttpStatus());
+            }
+        } else if (fieldName.equals("isSuspended")) {
+            if (ex.getBindingResult().getTarget() instanceof AdminUserReportRequestDto) {
+                ErrorResponse errorResponse = new ErrorResponse(
+                    ErrorCode.NOT_NULL_USER_REPORT_SUSPENDED_OR_NOT);
+                log.error(ErrorCode.INVALID_QUESTION_TITLE.getMessage());
+                return new ResponseEntity<>(errorResponse,
+                    ErrorCode.NOT_NULL_USER_REPORT_SUSPENDED_OR_NOT.getHttpStatus());
             }
         }
 

--- a/src/main/java/LinkerBell/campus_market_spring/global/error/exception/CustomException.java
+++ b/src/main/java/LinkerBell/campus_market_spring/global/error/exception/CustomException.java
@@ -12,4 +12,9 @@ public class CustomException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    public CustomException(ErrorCode errorCode, String message) {
+        super(message);
+        this.errorCode = errorCode;
+    }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/repository/BlacklistRepository.java
+++ b/src/main/java/LinkerBell/campus_market_spring/repository/BlacklistRepository.java
@@ -1,0 +1,13 @@
+package LinkerBell.campus_market_spring.repository;
+
+import LinkerBell.campus_market_spring.domain.Blacklist;
+import LinkerBell.campus_market_spring.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BlacklistRepository extends JpaRepository<Blacklist, Long> {
+
+    Optional<Blacklist> findByUser(User user);
+}

--- a/src/test/java/LinkerBell/campus_market_spring/admin/service/AdminServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/admin/service/AdminServiceTest.java
@@ -5,12 +5,16 @@ import static org.mockito.BDDMockito.*;
 
 import LinkerBell.campus_market_spring.domain.Role;
 import LinkerBell.campus_market_spring.domain.User;
+import LinkerBell.campus_market_spring.domain.UserReport;
 import LinkerBell.campus_market_spring.dto.AuthResponseDto;
 import LinkerBell.campus_market_spring.global.error.ErrorCode;
 import LinkerBell.campus_market_spring.global.error.exception.CustomException;
 import LinkerBell.campus_market_spring.global.jwt.JwtUtils;
+import LinkerBell.campus_market_spring.repository.BlacklistRepository;
+import LinkerBell.campus_market_spring.repository.UserReportRepository;
 import LinkerBell.campus_market_spring.repository.UserRepository;
 import LinkerBell.campus_market_spring.service.GoogleAuthService;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +34,12 @@ class AdminServiceTest {
 
     @Mock
     private UserRepository userRepository;
+
+    @Mock
+    private UserReportRepository userReportRepository;
+
+    @Mock
+    private BlacklistRepository blacklistRepository;
 
     @Mock
     private JwtUtils jwtUtils;
@@ -60,7 +70,7 @@ class AdminServiceTest {
     @DisplayName("관리자가 아닌 사용자 로그인 테스트")
     public void adminLoginWithoutAdminRoleTest() {
         // given
-        User user = createUser();
+        User user = createUser(100L);
         given(googleAuthService.getEmailWithVerifyIdToken(anyString()))
             .willReturn("test@example.com");
         given(userRepository.findByLoginEmail("test@example.com")).willReturn(Optional.ofNullable(user));
@@ -70,6 +80,27 @@ class AdminServiceTest {
             .hasMessage(ErrorCode.NOT_ADMINISTRATOR.getMessage());
     }
 
+    @Test
+    @DisplayName("사용자 신고 처리 테스트")
+    public void receiveUserReportTest() {
+        // given
+        User user = createUser(100L);
+        User target = createUser(101L);
+        UserReport userReport = createUserReport(user, target, 1L);
+
+        given(userReportRepository.findById(anyLong())).willReturn(Optional.ofNullable(userReport));
+        given(blacklistRepository.findByUser(any(User.class))).willReturn(Optional.empty());
+
+        // when
+        adminService.receiveUserReport(userReport.getUserReportId(), true, "test Reason", 5);
+
+        // then
+        then(blacklistRepository).should(times(1)).save(assertArg(b -> {
+            assertThat(b).isNotNull();
+            assertThat(b.getEndDate()).isAfter(LocalDateTime.now());
+        }));
+    }
+
     private User createAdmin() {
         return User.builder()
             .loginEmail("test@example.com")
@@ -77,10 +108,19 @@ class AdminServiceTest {
             .userId(1L).build();
     }
 
-    private User createUser() {
+    private User createUser(Long userId) {
         return User.builder()
-            .loginEmail("test@example.com")
+            .loginEmail("test" + userId + "@example.com")
             .role(Role.USER)
-            .userId(100L).build();
+            .userId(userId).build();
+    }
+
+    private UserReport createUserReport(User user, User target, Long id) {
+        return UserReport.builder()
+            .userReportId(id)
+            .user(user)
+            .target(target)
+            .description("test description" + id)
+            .isCompleted(false).build();
     }
 }

--- a/src/test/java/LinkerBell/campus_market_spring/repository/BlacklistRepositoryTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/repository/BlacklistRepositoryTest.java
@@ -1,0 +1,63 @@
+package LinkerBell.campus_market_spring.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import LinkerBell.campus_market_spring.domain.Blacklist;
+import LinkerBell.campus_market_spring.domain.Role;
+import LinkerBell.campus_market_spring.domain.User;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class BlacklistRepositoryTest {
+
+    @Autowired
+    private BlacklistRepository blacklistRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder().userId(1L).loginEmail("test@example.com")
+            .role(Role.USER).build();
+        user = userRepository.save(user);
+    }
+
+    @Test
+    @DisplayName("블랙리스트 저장 테스트")
+    public void saveBlacklistTest() {
+        // given
+        LocalDateTime period = LocalDateTime.now().plusDays(2);
+        Blacklist blacklist = Blacklist.builder().user(user).reason("test reason")
+            .endDate(period).build();
+        // when
+        Blacklist savedBlacklist = blacklistRepository.save(blacklist);
+        // then
+        assertThat(savedBlacklist).isNotNull();
+        assertThat(savedBlacklist.getUser()).isEqualTo(user);
+    }
+
+    @Test
+    @DisplayName("사용자로 블랙리스트 찾기 테스트")
+    public void findBlacklistByUserTest() {
+        // given
+        LocalDateTime period = LocalDateTime.now().plusDays(2);
+        Blacklist blacklist = Blacklist.builder().user(user).reason("test reason")
+            .endDate(period).build();
+        Blacklist savedBlacklist = blacklistRepository.save(blacklist);
+
+        // when
+        Blacklist findBlacklist = blacklistRepository.findByUser(user).orElse(null);
+
+        // then
+        assertThat(findBlacklist).isNotNull();
+        assertThat(findBlacklist.getUser()).isEqualTo(user);
+    }
+}


### PR DESCRIPTION
- 사용자 신고 접수 후 처리하는 기능 구현
- 접수되면 정지 사유와 기간을 블랙리스트에 저장
- 로그인 시 정지 여부를 확인하는 로직 추가
- 정지 사유를 에러 메시지에 추가하는 메소드 추가