### PR TITLE
feat: admin 캠퍼스 리스트 가져오는 기능 추가, admin 아이템 리스트 기능 추가

### DIFF
--- a/src/main/java/LinkerBell/campus_market_spring/admin/controller/AdminController.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package LinkerBell.campus_market_spring.admin.controller;
 
+import LinkerBell.campus_market_spring.admin.dto.AdminCampusesResponseDto;
 import LinkerBell.campus_market_spring.admin.dto.AdminItemReportRequestDto;
 import LinkerBell.campus_market_spring.admin.dto.AdminItemSearchResponseDto;
 import LinkerBell.campus_market_spring.admin.dto.AdminLoginRequestDto;
@@ -59,10 +60,12 @@ public class AdminController {
         @RequestParam(required = false) Category category,
         @RequestParam(required = false) Integer minPrice,
         @RequestParam(required = false) Integer maxPrice,
+        @RequestParam(required = false) Boolean isDeleted,
+        @RequestParam(required = false) Long campusId,
         @PageableDefault(page = 0, size = 10, sort = "createdDate", direction = Sort.Direction.DESC) Pageable pageable) {
         SliceResponse<AdminItemSearchResponseDto> response =
             adminService.getAllItems(user.getUserId(), name, category, minPrice, maxPrice,
-                pageable);
+                isDeleted, campusId, pageable);
 
         return ResponseEntity.ok(response);
     }
@@ -74,7 +77,8 @@ public class AdminController {
         @SortDefaults({
             @SortDefault(sort = "createdDate", direction = Direction.DESC),
             @SortDefault(sort = "itemReportId", direction = Direction.DESC)}) Pageable pageable) {
-        SliceResponse<ItemReportSearchResponseDto> response = adminService.getItemReports(status, pageable);
+        SliceResponse<ItemReportSearchResponseDto> response = adminService.getItemReports(status,
+            pageable);
         return ResponseEntity.ok(response);
     }
 
@@ -85,7 +89,8 @@ public class AdminController {
         @SortDefaults({
             @SortDefault(sort = "createdDate", direction = Direction.DESC),
             @SortDefault(sort = "userReportId", direction = Direction.DESC)}) Pageable pageable) {
-        SliceResponse<UserReportSearchResponseDto> response = adminService.getUserReports(status, pageable);
+        SliceResponse<UserReportSearchResponseDto> response = adminService.getUserReports(status,
+            pageable);
         return ResponseEntity.ok(response);
     }
 
@@ -125,7 +130,8 @@ public class AdminController {
         @SortDefaults({
             @SortDefault(sort = "createdDate", direction = Direction.DESC),
             @SortDefault(sort = "qaId", direction = Direction.DESC)}) Pageable pageable) {
-        SliceResponse<AdminQaSearchResponseDto> response = adminService.getQuestions(status, pageable);
+        SliceResponse<AdminQaSearchResponseDto> response = adminService.getQuestions(status,
+            pageable);
         return ResponseEntity.ok(response);
     }
 
@@ -160,5 +166,10 @@ public class AdminController {
         @PathVariable("userId") Long userId) {
         OtherProfileResponseDto response = adminService.getUserProfile(userId);
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/campuses")
+    public ResponseEntity<AdminCampusesResponseDto> getCampuses() {
+        return ResponseEntity.ok(adminService.getCampuses());
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminCampusResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminCampusResponseDto.java
@@ -1,0 +1,16 @@
+package LinkerBell.campus_market_spring.admin.dto;
+
+import LinkerBell.campus_market_spring.domain.Campus;
+import lombok.Data;
+
+@Data
+public class AdminCampusResponseDto {
+
+    private Long campusId;
+    private String campusName;
+
+    public AdminCampusResponseDto(Campus campus) {
+        this.campusId = campus.getCampusId();
+        this.campusName = campus.getUniversityName() + " " + campus.getRegion();
+    }
+}

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminCampusesResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminCampusesResponseDto.java
@@ -1,0 +1,16 @@
+package LinkerBell.campus_market_spring.admin.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminCampusesResponseDto {
+
+    private List<AdminCampusResponseDto> campuses;
+}

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminItemSearchResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminItemSearchResponseDto.java
@@ -1,7 +1,9 @@
 package LinkerBell.campus_market_spring.admin.dto;
 
 import LinkerBell.campus_market_spring.domain.ItemStatus;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
 
 public record AdminItemSearchResponseDto(
     Long itemId,
@@ -16,7 +18,12 @@ public record AdminItemSearchResponseDto(
     @JsonProperty(value = "isLiked") Boolean isLiked,
     String universityName,
     String campusRegion,
-    Long campusId
+    Long campusId,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime createdDate,
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime lastModifiedDate,
+    @JsonProperty(value = "isDeleted") Boolean isDeleted
 ) {
 
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/service/AdminService.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/service/AdminService.java
@@ -1,11 +1,14 @@
 package LinkerBell.campus_market_spring.admin.service;
 
+import LinkerBell.campus_market_spring.admin.dto.AdminCampusResponseDto;
+import LinkerBell.campus_market_spring.admin.dto.AdminCampusesResponseDto;
 import LinkerBell.campus_market_spring.admin.dto.AdminItemSearchResponseDto;
 import LinkerBell.campus_market_spring.admin.dto.AdminQaResponseDto;
 import LinkerBell.campus_market_spring.admin.dto.AdminQaSearchResponseDto;
 import LinkerBell.campus_market_spring.admin.dto.ItemReportSearchResponseDto;
 import LinkerBell.campus_market_spring.admin.dto.UserReportSearchResponseDto;
 import LinkerBell.campus_market_spring.domain.Blacklist;
+import LinkerBell.campus_market_spring.domain.Campus;
 import LinkerBell.campus_market_spring.domain.Category;
 import LinkerBell.campus_market_spring.admin.dto.ItemReportResponseDto;
 import LinkerBell.campus_market_spring.admin.dto.UserReportResponseDto;
@@ -23,6 +26,7 @@ import LinkerBell.campus_market_spring.global.error.ErrorCode;
 import LinkerBell.campus_market_spring.global.error.exception.CustomException;
 import LinkerBell.campus_market_spring.global.jwt.JwtUtils;
 import LinkerBell.campus_market_spring.repository.BlacklistRepository;
+import LinkerBell.campus_market_spring.repository.CampusRepository;
 import LinkerBell.campus_market_spring.repository.ItemReportRepository;
 import LinkerBell.campus_market_spring.repository.ItemRepository;
 import LinkerBell.campus_market_spring.repository.QaRepository;
@@ -30,6 +34,7 @@ import LinkerBell.campus_market_spring.repository.UserReportRepository;
 import LinkerBell.campus_market_spring.repository.UserRepository;
 import LinkerBell.campus_market_spring.service.GoogleAuthService;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -52,6 +57,7 @@ public class AdminService {
     private final ItemRepository itemRepository;
     private final BlacklistRepository blacklistRepository;
     private final QaRepository qaRepository;
+    private final CampusRepository campusRepository;
 
     public AuthResponseDto adminLogin(String idToken) {
         String email = googleAuthService.getEmailWithVerifyIdToken(idToken);
@@ -76,7 +82,8 @@ public class AdminService {
     }
 
     @Transactional(readOnly = true)
-    public SliceResponse<ItemReportSearchResponseDto> getItemReports(String status, Pageable pageable) {
+    public SliceResponse<ItemReportSearchResponseDto> getItemReports(String status,
+        Pageable pageable) {
         Slice<ItemReport> itemReports;
         if (StringUtils.equals(status, "all")) {
             itemReports = itemReportRepository.findItemReports(pageable);
@@ -89,7 +96,8 @@ public class AdminService {
     }
 
     @Transactional(readOnly = true)
-    public SliceResponse<UserReportSearchResponseDto> getUserReports(String status, Pageable pageable) {
+    public SliceResponse<UserReportSearchResponseDto> getUserReports(String status,
+        Pageable pageable) {
         Slice<UserReport> userReports;
         if (StringUtils.equals(status, "all")) {
             userReports = userReportRepository.findUserReports(pageable);
@@ -103,8 +111,10 @@ public class AdminService {
 
     @Transactional(readOnly = true)
     public SliceResponse<AdminItemSearchResponseDto> getAllItems(Long userId, String name,
-        Category category, Integer minPrice, Integer maxPrice, Pageable pageable) {
-        return itemRepository.adminItemSearch(userId, name, category, minPrice, maxPrice, pageable);
+        Category category, Integer minPrice, Integer maxPrice, Boolean isDeleted, Long campusId,
+        Pageable pageable) {
+        return itemRepository.adminItemSearch(userId, name, category, minPrice, maxPrice, isDeleted,
+            campusId, pageable);
     }
 
     @Transactional(readOnly = true)
@@ -213,5 +223,13 @@ public class AdminService {
             .profileImage(user.getProfileImage())
             .rating(user.getRating())
             .isDeleted(user.isDeleted()).build();
+    }
+
+    @Transactional(readOnly = true)
+    public AdminCampusesResponseDto getCampuses() {
+        List<Campus> campus = campusRepository.findAll();
+        List<AdminCampusResponseDto> campuses = campus.stream()
+            .map(AdminCampusResponseDto::new).toList();
+        return AdminCampusesResponseDto.builder().campuses(campuses).build();
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/LinkerBell/campus_market_spring/global/error/GlobalExceptionHandler.java
@@ -72,6 +72,16 @@ public class GlobalExceptionHandler {
             log.error(ErrorCode.INVALID_ITEM_STATUS.getMessage());
             return new ResponseEntity<>(errorResponse,
                 ErrorCode.INVALID_ITEM_STATUS.getHttpStatus());
+        } else if (ex.getName().equals("isDeleted")) {
+            ErrorResponse errorResponse = new ErrorResponse(ErrorCode.REQUIRE_DELETE_OR_NOT);
+            log.error(ErrorCode.REQUIRE_DELETE_OR_NOT.getMessage());
+            return new ResponseEntity<>(errorResponse,
+                ErrorCode.REQUIRE_DELETE_OR_NOT.getHttpStatus());
+        } else if (ex.getName().equals("campusId")) {
+            ErrorResponse errorResponse = new ErrorResponse(ErrorCode.CAMPUS_NOT_FOUND);
+            log.error(ErrorCode.CAMPUS_NOT_FOUND.getMessage());
+            return new ResponseEntity<>(errorResponse,
+                ErrorCode.CAMPUS_NOT_FOUND.getHttpStatus());
         }
 
         throw ex;

--- a/src/main/java/LinkerBell/campus_market_spring/repository/ItemRepositoryCustom.java
+++ b/src/main/java/LinkerBell/campus_market_spring/repository/ItemRepositoryCustom.java
@@ -17,5 +17,6 @@ public interface ItemRepositoryCustom {
     ItemDetailsViewResponseDto findByItemDetails(Long userId, Long itemId);
 
     SliceResponse<AdminItemSearchResponseDto> adminItemSearch(Long userId, String name,
-        Category category, Integer minPrice, Integer maxPrice, Pageable pageable);
+        Category category, Integer minPrice, Integer maxPrice, Boolean isDeleted, Long campusId,
+        Pageable pageable);
 }

--- a/src/main/java/LinkerBell/campus_market_spring/repository/ItemRepositoryImpl.java
+++ b/src/main/java/LinkerBell/campus_market_spring/repository/ItemRepositoryImpl.java
@@ -149,7 +149,8 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
 
     @Override
     public SliceResponse<AdminItemSearchResponseDto> adminItemSearch(Long userId, String name,
-        Category category, Integer minPrice, Integer maxPrice, Pageable pageable) {
+        Category category, Integer minPrice, Integer maxPrice, Boolean isDeleted, Long campusId,
+        Pageable pageable) {
         QItem item = QItem.item;
         QUser user = QUser.user;
         QChatRoom chatRoom = QChatRoom.chatRoom;
@@ -177,7 +178,10 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
                     .as("isLiked"),
                 item.campus.universityName,
                 item.campus.region,
-                item.campus.campusId
+                item.campus.campusId,
+                item.createdDate,
+                item.lastModifiedDate,
+                item.isDeleted
             ))
             .from(item)
             .leftJoin(item.user, user)
@@ -186,7 +190,9 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
             .where(
                 itemNameContains(name),
                 itemCategoryEq(category),
-                itemPriceBetween(minPrice, maxPrice)
+                itemPriceBetween(minPrice, maxPrice),
+                itemCampusEq(campusId),
+                itemIsDeletedEq(isDeleted)
             )
             .groupBy(item.itemId)
             .offset(pageable.getOffset())
@@ -249,6 +255,14 @@ public class ItemRepositoryImpl implements ItemRepositoryCustom {
 
     private BooleanExpression itemStatusEq(ItemStatus itemStatus) {
         return itemStatus != null ? item.itemStatus.eq(itemStatus) : null;
+    }
+
+    private BooleanExpression itemIsDeletedEq(Boolean isDeleted) {
+        return isDeleted != null ? item.isDeleted.eq(isDeleted) : null;
+    }
+
+    private BooleanExpression itemCampusEq(Long campusId) {
+        return campusId != null ? item.campus.campusId.eq(campusId) : null;
     }
 
     private OrderSpecifier<?>[] itemSearchSort(Pageable pageable) {

--- a/src/test/java/LinkerBell/campus_market_spring/admin/service/AdminServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/admin/service/AdminServiceTest.java
@@ -1,8 +1,18 @@
 package LinkerBell.campus_market_spring.admin.service;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.any;
+import static org.mockito.BDDMockito.anyBoolean;
+import static org.mockito.BDDMockito.anyLong;
+import static org.mockito.BDDMockito.anyString;
+import static org.mockito.BDDMockito.assertArg;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.times;
 
+import LinkerBell.campus_market_spring.admin.dto.AdminCampusesResponseDto;
+import LinkerBell.campus_market_spring.domain.Campus;
 import LinkerBell.campus_market_spring.domain.ItemReport;
 import LinkerBell.campus_market_spring.domain.QA;
 import LinkerBell.campus_market_spring.domain.Role;
@@ -13,6 +23,7 @@ import LinkerBell.campus_market_spring.global.error.ErrorCode;
 import LinkerBell.campus_market_spring.global.error.exception.CustomException;
 import LinkerBell.campus_market_spring.global.jwt.JwtUtils;
 import LinkerBell.campus_market_spring.repository.BlacklistRepository;
+import LinkerBell.campus_market_spring.repository.CampusRepository;
 import LinkerBell.campus_market_spring.repository.ItemReportRepository;
 import LinkerBell.campus_market_spring.repository.QaRepository;
 import LinkerBell.campus_market_spring.repository.UserReportRepository;
@@ -21,7 +32,6 @@ import LinkerBell.campus_market_spring.service.GoogleAuthService;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-import org.assertj.core.internal.Lists;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,11 +42,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
-import org.springframework.mock.web.MockPageContext;
 
 @ExtendWith(MockitoExtension.class)
 class AdminServiceTest {
@@ -63,6 +70,9 @@ class AdminServiceTest {
     private ItemReportRepository itemReportRepository;
 
     @Mock
+    private CampusRepository campusRepository;
+
+    @Mock
     private JwtUtils jwtUtils;
 
     @Test
@@ -74,7 +84,8 @@ class AdminServiceTest {
         String refreshToken = "testRefreshToken";
         given(googleAuthService.getEmailWithVerifyIdToken(anyString()))
             .willReturn("test@example.com");
-        given(userRepository.findByLoginEmail("test@example.com")).willReturn(Optional.ofNullable(admin));
+        given(userRepository.findByLoginEmail("test@example.com")).willReturn(
+            Optional.ofNullable(admin));
         given(jwtUtils.generateAccessToken(anyLong(), anyString(), any(Role.class)))
             .willReturn(accessToken);
         given(jwtUtils.generateRefreshToken(anyLong(), anyString(), any(Role.class)))
@@ -94,7 +105,8 @@ class AdminServiceTest {
         User user = createUser(100L);
         given(googleAuthService.getEmailWithVerifyIdToken(anyString()))
             .willReturn("test@example.com");
-        given(userRepository.findByLoginEmail("test@example.com")).willReturn(Optional.ofNullable(user));
+        given(userRepository.findByLoginEmail("test@example.com")).willReturn(
+            Optional.ofNullable(user));
         // when & then
         assertThatThrownBy(() -> adminService.adminLogin("testIdToken"))
             .isInstanceOf(CustomException.class)
@@ -153,7 +165,8 @@ class AdminServiceTest {
         String status = "done";
 
         Page<QA> pageResponse = new PageImpl<>(List.of(), pageable, 0);
-        given(qaRepository.findQAsByStatus(anyBoolean(), any(Pageable.class))).willReturn(pageResponse);
+        given(qaRepository.findQAsByStatus(anyBoolean(), any(Pageable.class))).willReturn(
+            pageResponse);
         // when
         adminService.getQuestions(status, pageable);
         // then
@@ -177,7 +190,8 @@ class AdminServiceTest {
         String status = "inprogress";
 
         Page<QA> pageResponse = new PageImpl<>(List.of(), pageable, 0);
-        given(qaRepository.findQAsByStatus(anyBoolean(), any(Pageable.class))).willReturn(pageResponse);
+        given(qaRepository.findQAsByStatus(anyBoolean(), any(Pageable.class))).willReturn(
+            pageResponse);
         // when
         adminService.getQuestions(status, pageable);
         // then
@@ -219,7 +233,8 @@ class AdminServiceTest {
         Pageable pageable = PageRequest.of(0, 20, sort);
         String status = "done";
         Page<ItemReport> pageResponse = new PageImpl<>(List.of(), pageable, 0);
-        given(itemReportRepository.findItemReportsByStatus(anyBoolean(), any(Pageable.class))).willReturn(pageResponse);
+        given(itemReportRepository.findItemReportsByStatus(anyBoolean(),
+            any(Pageable.class))).willReturn(pageResponse);
         // when
         adminService.getItemReports(status, pageable);
         // then
@@ -239,7 +254,8 @@ class AdminServiceTest {
         Pageable pageable = PageRequest.of(0, 20, sort);
         String status = "inprogress";
         Page<ItemReport> pageResponse = new PageImpl<>(List.of(), pageable, 0);
-        given(itemReportRepository.findItemReportsByStatus(anyBoolean(), any(Pageable.class))).willReturn(pageResponse);
+        given(itemReportRepository.findItemReportsByStatus(anyBoolean(),
+            any(Pageable.class))).willReturn(pageResponse);
         // when
         adminService.getItemReports(status, pageable);
         // then
@@ -278,7 +294,8 @@ class AdminServiceTest {
         Pageable pageable = PageRequest.of(0, 20, sort);
         String status = "inprogress";
         Page<UserReport> pageResponse = new PageImpl<>(List.of(), pageable, 0);
-        given(userReportRepository.findUserReportsByStatus(anyBoolean(), any(Pageable.class))).willReturn(pageResponse);
+        given(userReportRepository.findUserReportsByStatus(anyBoolean(),
+            any(Pageable.class))).willReturn(pageResponse);
         // when
         adminService.getUserReports(status, pageable);
         // then
@@ -298,7 +315,8 @@ class AdminServiceTest {
         Pageable pageable = PageRequest.of(0, 20, sort);
         String status = "done";
         Page<UserReport> pageResponse = new PageImpl<>(List.of(), pageable, 0);
-        given(userReportRepository.findUserReportsByStatus(anyBoolean(), any(Pageable.class))).willReturn(pageResponse);
+        given(userReportRepository.findUserReportsByStatus(anyBoolean(),
+            any(Pageable.class))).willReturn(pageResponse);
         // when
         adminService.getUserReports(status, pageable);
         // then
@@ -307,6 +325,44 @@ class AdminServiceTest {
             assertThat(st).isNotNull();
             assertThat(st).isTrue();
         }), any());
+    }
+
+    @Test
+    @DisplayName("캠퍼스 목록 가져오기 테스트")
+    public void getCampusesTest() {
+        // given
+        Campus campus1 = Campus.builder()
+            .campusId(1L)
+            .universityName("Seoul National University")
+            .region("Seoul")
+            .build();
+
+        Campus campus2 = Campus.builder()
+            .campusId(2L)
+            .universityName("Korea University")
+            .region("Seoul")
+            .build();
+
+        List<Campus> campusList = List.of(campus1, campus2);
+        given(campusRepository.findAll()).willReturn(campusList);
+
+        // when
+        AdminCampusesResponseDto responseDto = adminService.getCampuses();
+
+        // then
+        assertThat(responseDto).isNotNull();
+        assertThat(responseDto.getCampuses()).isNotNull();
+        assertThat(responseDto.getCampuses()).hasSize(2);
+
+        assertThat(responseDto.getCampuses().get(0).getCampusId()).isEqualTo(1L);
+        assertThat(responseDto.getCampuses().get(0).getCampusName())
+            .isEqualTo("Seoul National University Seoul");
+
+        assertThat(responseDto.getCampuses().get(1).getCampusId()).isEqualTo(2L);
+        assertThat(responseDto.getCampuses().get(1).getCampusName())
+            .isEqualTo("Korea University Seoul");
+
+        then(campusRepository).should(times(1)).findAll();
     }
 
     private User createAdmin() {

--- a/src/test/java/LinkerBell/campus_market_spring/repository/CampusRepositoryTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/repository/CampusRepositoryTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
 @DataJpaTest
 class CampusRepositoryTest {
+
     @Autowired
     CampusRepository campusRepository;
 
@@ -43,6 +44,17 @@ class CampusRepositoryTest {
         List<Campus> campusList = campusRepository.findByEmail(email);
         // then
         assertThat(campusList.size()).isEqualTo(0);
+        System.out.println(campusList);
+    }
+
+    @Test
+    @DisplayName("모든 캠퍼스 가져오는 테스트")
+    public void getAllCampusTest() {
+        // given
+        List<Campus> campusList = campusRepository.findAll();
+        // when & then
+        assertThat(campusList).isNotNull();
+        assertThat(campusList.size()).isEqualTo(2);
         System.out.println(campusList);
     }
 


### PR DESCRIPTION
* admin 캠퍼스 목록 리스트 가져오는 기능 및 테스트 추가
* admin에서 아이템 목록을 가져올 때, 최종 수정 날짜, 마지막 수정 날짜, 삭제 여부를 response에 추가 했고,
request 파라미터에 대학교 id 와 삭제 여부를 추가하여 이에 대해 필터링 할 수 있게 추가