### PR TITLE
fix: 관리자용 문의 및 사용자 신고 상세 내용 정보 수정 외 1가지

### DIFF
--- a/src/main/java/LinkerBell/campus_market_spring/admin/controller/AdminController.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/controller/AdminController.java
@@ -50,7 +50,7 @@ public class AdminController {
     @PostMapping("/login")
     public ResponseEntity<AuthResponseDto> adminLogin(
         @RequestBody AdminLoginRequestDto requestDto) {
-        AuthResponseDto authResponseDto = adminService.adminLogin(requestDto.idToken());
+        AuthResponseDto authResponseDto = adminService.adminLogin(requestDto.getIdToken());
         return ResponseEntity.ok(authResponseDto);
     }
 
@@ -113,15 +113,15 @@ public class AdminController {
     @PatchMapping("/items/report/{itemReportId}")
     public ResponseEntity<?> receiveItemReport(@PathVariable("itemReportId") Long itemReportId,
         @Valid @RequestBody AdminItemReportRequestDto requestDto) {
-        adminService.receiveItemReport(itemReportId, requestDto.isDeleted());
+        adminService.receiveItemReport(itemReportId, requestDto.getIsDeleted());
         return ResponseEntity.noContent().build();
     }
 
     @PatchMapping("/users/report/{userReportId}")
     public ResponseEntity<?> receiveUserReport(@PathVariable("userReportId") Long userReportId,
         @Valid @RequestBody AdminUserReportRequestDto requestDto) {
-        adminService.receiveUserReport(userReportId, requestDto.isSuspended(),
-            requestDto.suspendReason(), requestDto.suspendPeriod());
+        adminService.receiveUserReport(userReportId, requestDto.getIsSuspended(),
+            requestDto.getSuspendReason(), requestDto.getSuspendPeriod());
         return ResponseEntity.noContent().build();
     }
 
@@ -146,7 +146,7 @@ public class AdminController {
     @PatchMapping("/qa/{qaId}")
     public ResponseEntity<?> answerQuestion(@PathVariable("qaId") Long qaId,
         @Valid @RequestBody AdminQaRequestDto requestDto) {
-        adminService.answerQuestion(qaId, requestDto.answerDescription());
+        adminService.answerQuestion(qaId, requestDto.getAnswerDescription());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminItemReportRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminItemReportRequestDto.java
@@ -1,9 +1,11 @@
 package LinkerBell.campus_market_spring.admin.dto;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 
-public record AdminItemReportRequestDto(
-    @NotNull(message = "삭제 처리 여부가 필요합니다.") Boolean isDeleted
-) {
+@Getter
+public class AdminItemReportRequestDto {
 
+    @NotNull(message = "삭제 처리 여부가 필요합니다.")
+    private Boolean isDeleted;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminItemSearchResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminItemSearchResponseDto.java
@@ -4,26 +4,49 @@ import LinkerBell.campus_market_spring.domain.ItemStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record AdminItemSearchResponseDto(
-    Long itemId,
-    Long userId,
-    String nickname,
-    String thumbnail,
-    String title,
-    Integer price,
-    Integer chatCount,
-    Integer likeCount,
-    ItemStatus itemStatus,
-    @JsonProperty(value = "isLiked") Boolean isLiked,
-    String universityName,
-    String campusRegion,
-    Long campusId,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    LocalDateTime createdDate,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-    LocalDateTime lastModifiedDate,
-    @JsonProperty(value = "isDeleted") Boolean isDeleted
-) {
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminItemSearchResponseDto {
 
+    private Long itemId;
+
+    private Long userId;
+
+    private String nickname;
+
+    private String thumbnail;
+
+    private String title;
+
+    private Integer price;
+
+    private Integer chatCount;
+
+    private Integer likeCount;
+
+    private ItemStatus itemStatus;
+
+    @JsonProperty(value = "isLiked")
+    private Boolean isLiked;
+
+    private String universityName;
+
+    private String campusRegion;
+
+    private Long campusId;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime createdDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private LocalDateTime lastModifiedDate;
+
+    @JsonProperty(value = "isDeleted") private Boolean isDeleted;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminLoginRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminLoginRequestDto.java
@@ -1,5 +1,9 @@
 package LinkerBell.campus_market_spring.admin.dto;
 
-public record AdminLoginRequestDto(String idToken) {
+import lombok.Getter;
 
+@Getter
+public class AdminLoginRequestDto {
+
+    private String idToken;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminQaRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminQaRequestDto.java
@@ -2,9 +2,10 @@ package LinkerBell.campus_market_spring.admin.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
 
-public record AdminQaRequestDto(
-    @NotBlank @Size(min = 2, max = 500) String answerDescription
-) {
+@Getter
+public class AdminQaRequestDto {
 
+    @NotBlank @Size(min = 2, max = 500) private String answerDescription;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminQaResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminQaResponseDto.java
@@ -2,7 +2,9 @@ package LinkerBell.campus_market_spring.admin.dto;
 
 import LinkerBell.campus_market_spring.domain.QA;
 import LinkerBell.campus_market_spring.domain.QaCategory;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,6 +22,8 @@ public class AdminQaResponseDto {
     private String description;
     private QaCategory category;
     @JsonProperty(value = "isCompleted") private Boolean isCompleted;
+    private String answerDescription;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") private LocalDateTime answerDate;
 
     public AdminQaResponseDto(QA qa) {
         this.qaId = qa.getQaId();
@@ -28,5 +32,10 @@ public class AdminQaResponseDto {
         this.description = qa.getDescription();
         this.category = qa.getCategory();
         this.isCompleted = qa.isCompleted();
+
+        if (this.isCompleted) {
+            this.answerDescription = qa.getAnswerDescription();
+            this.answerDate = qa.getAnswerDate();
+        }
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminQaResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminQaResponseDto.java
@@ -3,19 +3,30 @@ package LinkerBell.campus_market_spring.admin.dto;
 import LinkerBell.campus_market_spring.domain.QA;
 import LinkerBell.campus_market_spring.domain.QaCategory;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record AdminQaResponseDto(
-    Long qaId,
-    Long userId,
-    String title,
-    String description,
-    QaCategory category,
-    @JsonProperty(value = "isCompleted") Boolean isCompleted
-) {
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminQaResponseDto {
+
+    private Long qaId;
+    private Long userId;
+    private String title;
+    private String description;
+    private QaCategory category;
+    @JsonProperty(value = "isCompleted") private Boolean isCompleted;
 
     public AdminQaResponseDto(QA qa) {
-        this(qa.getQaId(), qa.getUser().getUserId(),
-            qa.getTitle(), qa.getDescription(),
-            qa.getCategory(), qa.isCompleted());
+        this.qaId = qa.getQaId();
+        this.userId = qa.getUser().getUserId();
+        this.title = qa.getTitle();
+        this.description = qa.getDescription();
+        this.category = qa.getCategory();
+        this.isCompleted = qa.isCompleted();
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminQaSearchResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminQaSearchResponseDto.java
@@ -5,19 +5,31 @@ import LinkerBell.campus_market_spring.domain.QaCategory;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record AdminQaSearchResponseDto(
-    Long qaId,
-    Long userId,
-    QaCategory category,
-    String title,
-    @JsonProperty(value = "isCompleted") Boolean isComplete,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime createdDate
-    ) {
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AdminQaSearchResponseDto {
+
+    private Long qaId;
+    private Long userId;
+    private QaCategory category;
+    private String title;
+    @JsonProperty(value = "isCompleted") private Boolean isCompleted;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") private LocalDateTime createdDate;
 
     public AdminQaSearchResponseDto(QA qa) {
-        this(qa.getQaId(), qa.getUser().getUserId(),
-            qa.getCategory(), qa.getTitle(), qa.isCompleted(),
-            qa.getCreatedDate());
+        this.qaId = qa.getQaId();
+        this.userId = qa.getUser().getUserId();
+        this.category = qa.getCategory();
+        this.title = qa.getTitle();
+        this.createdDate = qa.getCreatedDate();
+        this.isCompleted = qa.isCompleted();
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminUserReportRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/AdminUserReportRequestDto.java
@@ -1,11 +1,13 @@
 package LinkerBell.campus_market_spring.admin.dto;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 
-public record AdminUserReportRequestDto(
-    @NotNull Boolean isSuspended,
-    String suspendReason,
-    Integer suspendPeriod
-) {
+@Getter
+public class AdminUserReportRequestDto {
 
+    @NotNull
+    private Boolean isSuspended;
+    private String suspendReason;
+    private Integer suspendPeriod;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/ItemReportResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/ItemReportResponseDto.java
@@ -3,18 +3,30 @@ package LinkerBell.campus_market_spring.admin.dto;
 import LinkerBell.campus_market_spring.domain.ItemReport;
 import LinkerBell.campus_market_spring.domain.ItemReportCategory;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record ItemReportResponseDto(
-    Long itemReportId,
-    Long itemId,
-    Long userId,
-    String description,
-    ItemReportCategory category,
-    @JsonProperty(value = "isCompleted") Boolean isCompleted) {
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemReportResponseDto {
+
+    private Long itemReportId;
+    private Long itemId;
+    private Long userId;
+    private String description;
+    private ItemReportCategory category;
+    @JsonProperty(value = "isCompleted") private Boolean isCompleted;
 
     public ItemReportResponseDto(ItemReport itemReport) {
-        this(itemReport.getItemReportId(), itemReport.getItem().getItemId(),
-            itemReport.getUser().getUserId(), itemReport.getDescription(),
-            itemReport.getCategory(), itemReport.isCompleted());
+        this.itemId = itemReport.getItem().getItemId();
+        this.itemReportId = itemReport.getItemReportId();
+        this.userId = itemReport.getUser().getUserId();
+        this.description = itemReport.getDescription();
+        this.category = itemReport.getCategory();
+        this.isCompleted = itemReport.isCompleted();
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/ItemReportSearchResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/ItemReportSearchResponseDto.java
@@ -3,15 +3,23 @@ package LinkerBell.campus_market_spring.admin.dto;
 import LinkerBell.campus_market_spring.domain.ItemReport;
 import LinkerBell.campus_market_spring.domain.ItemReportCategory;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record ItemReportSearchResponseDto(
-    Long itemReportId,
-    Long itemId,
-    Long userId,
-    ItemReportCategory category,
-    String description,
-    @JsonProperty(value = "isCompleted") Boolean isCompleted
-) {
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ItemReportSearchResponseDto {
+
+    private Long itemReportId;
+    private Long itemId;
+    private Long userId;
+    private ItemReportCategory category;
+    private String description;
+    @JsonProperty(value = "isCompleted") private Boolean isCompleted;
 
     public ItemReportSearchResponseDto(ItemReport itemReport) {
         this(itemReport.getItemReportId(), itemReport.getItem().getItemId(),

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/UserReportResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/UserReportResponseDto.java
@@ -20,10 +20,22 @@ public class UserReportResponseDto {
     private String description;
     private UserReportCategory category;
     @JsonProperty(value = "isCompleted") private Boolean isCompleted;
+    @JsonProperty(value = "isSuspended") private Boolean isSuspended;
+    private String suspendReason;
+    private Integer suspendPeriod;
 
     public UserReportResponseDto(UserReport userReport) {
-        this(userReport.getUserReportId(), userReport.getUser().getUserId(),
-            userReport.getTarget().getUserId(), userReport.getDescription(),
-            userReport.getCategory(), userReport.isCompleted());
+        this.userReportId = userReport.getUserReportId();
+        this.userId = userReport.getUser().getUserId();
+        this.targetId = userReport.getTarget().getUserId();
+        this.description = userReport.getDescription();
+        this.category = userReport.getCategory();
+        this.isCompleted = userReport.isCompleted();
+        this.isSuspended = userReport.isSuspended();
+
+        if (this.isSuspended) {
+            this.suspendReason = userReport.getSuspendReason();
+            this.suspendPeriod = userReport.getSuspendPeriod();
+        }
     }
 }

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/UserReportResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/UserReportResponseDto.java
@@ -3,15 +3,23 @@ package LinkerBell.campus_market_spring.admin.dto;
 import LinkerBell.campus_market_spring.domain.UserReport;
 import LinkerBell.campus_market_spring.domain.UserReportCategory;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record UserReportResponseDto(
-    Long userReportId,
-    Long userId,
-    Long targetId,
-    String description,
-    UserReportCategory category,
-    @JsonProperty(value = "isCompleted") Boolean isCompleted
-) {
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserReportResponseDto {
+
+    private Long userReportId;
+    private Long userId;
+    private Long targetId;
+    private String description;
+    private UserReportCategory category;
+    @JsonProperty(value = "isCompleted") private Boolean isCompleted;
 
     public UserReportResponseDto(UserReport userReport) {
         this(userReport.getUserReportId(), userReport.getUser().getUserId(),

--- a/src/main/java/LinkerBell/campus_market_spring/admin/dto/UserReportSearchResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/dto/UserReportSearchResponseDto.java
@@ -3,15 +3,23 @@ package LinkerBell.campus_market_spring.admin.dto;
 import LinkerBell.campus_market_spring.domain.UserReport;
 import LinkerBell.campus_market_spring.domain.UserReportCategory;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record UserReportSearchResponseDto(
-    Long userReportId,
-    Long userId,
-    Long targetId,
-    UserReportCategory category,
-    String description,
-    @JsonProperty(value = "isCompleted") Boolean isCompleted
-) {
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserReportSearchResponseDto {
+
+    private Long userReportId;
+    private Long userId;
+    private Long targetId;
+    private UserReportCategory category;
+    private String description;
+    @JsonProperty(value = "isCompleted") private Boolean isCompleted;
 
     public UserReportSearchResponseDto(UserReport userReport) {
         this(userReport.getUserReportId(), userReport.getUser().getUserId(),

--- a/src/main/java/LinkerBell/campus_market_spring/admin/service/AdminService.java
+++ b/src/main/java/LinkerBell/campus_market_spring/admin/service/AdminService.java
@@ -153,8 +153,13 @@ public class AdminService {
         userReport.setCompleted(true);
 
         if (!isSuspended) {
+            userReport.setSuspended(false);
             return;
         }
+
+        userReport.setSuspendReason(suspendReason);
+        userReport.setSuspendPeriod(suspendPeriod);
+
         LocalDateTime period = LocalDateTime.now().plusDays(suspendPeriod);
         User target = userReport.getTarget();
         Blacklist blacklist = blacklistRepository.findByUser(target)

--- a/src/main/java/LinkerBell/campus_market_spring/controller/QaController.java
+++ b/src/main/java/LinkerBell/campus_market_spring/controller/QaController.java
@@ -39,8 +39,8 @@ public class QaController {
     @PostMapping("/questions")
     public ResponseEntity<?> postQuestion(@Login AuthUserDto user,
         @Valid @RequestBody QaRequestDto requestDto) {
-        qaService.postQuestion(user.getUserId(), requestDto.title(), requestDto.description(),
-            requestDto.category());
+        qaService.postQuestion(user.getUserId(), requestDto.getTitle(), requestDto.getDescription(),
+            requestDto.getCategory());
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/LinkerBell/campus_market_spring/domain/UserReport.java
+++ b/src/main/java/LinkerBell/campus_market_spring/domain/UserReport.java
@@ -41,4 +41,8 @@ public class UserReport extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserReportCategory category;
     private boolean isCompleted;
+    private boolean isSuspended;
+    @Column(length = 1000)
+    private String suspendReason;
+    private Integer suspendPeriod;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/dto/ItemReportCategoryResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/dto/ItemReportCategoryResponseDto.java
@@ -2,8 +2,16 @@ package LinkerBell.campus_market_spring.dto;
 
 import LinkerBell.campus_market_spring.domain.ItemReportCategory;
 import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record ItemReportCategoryResponseDto(ItemReportCategory[] categories) implements
-    Serializable {
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class ItemReportCategoryResponseDto {
 
+    private ItemReportCategory[] categories;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/dto/QaCategoryResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/dto/QaCategoryResponseDto.java
@@ -1,7 +1,15 @@
 package LinkerBell.campus_market_spring.dto;
 
 import LinkerBell.campus_market_spring.domain.QaCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record QaCategoryResponseDto(QaCategory[] categories) {
-
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class QaCategoryResponseDto {
+    private QaCategory[] categories;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/dto/QaRequestDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/dto/QaRequestDto.java
@@ -4,10 +4,18 @@ import LinkerBell.campus_market_spring.domain.QaCategory;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.Getter;
 
-public record QaRequestDto(
-    @NotBlank @Size(min = 2, max = 50, message = "문의 제목은 2자 이상 50자 이하입니다.") String title,
-    @NotNull QaCategory category,
-    @NotBlank @Size(min = 2, max = 500, message = "문의 내용은 2자 이상 500 이하입니다.") String description) {
+@Getter
+public class QaRequestDto {
 
+    @NotBlank
+    @Size(min = 2, max = 50, message = "문의 제목은 2자 이상 50자 이하입니다.")
+    private String title;
+
+    @NotNull private QaCategory category;
+
+    @NotBlank
+    @Size(min = 2, max = 500, message = "문의 내용은 2자 이상 500 이하입니다.")
+    private String description;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/dto/QaResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/dto/QaResponseDto.java
@@ -5,18 +5,26 @@ import LinkerBell.campus_market_spring.domain.QaCategory;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record QaResponseDto(
-    Long qaId,
-    Long userId,
-    String title,
-    String description,
-    QaCategory category,
-    @JsonProperty(value = "isCompleted") Boolean isCompleted,
-    String answerDescription,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime answerDate,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime createdDate
-) {
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class QaResponseDto {
+
+    private Long qaId;
+    private Long userId;
+    private String title;
+    private String description;
+    private QaCategory category;
+    @JsonProperty(value = "isCompleted") private Boolean isCompleted;
+    private String answerDescription;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") private LocalDateTime answerDate;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") private LocalDateTime createdDate;
 
     public QaResponseDto(QA qa) {
         this(qa.getQaId(), qa.getUser().getUserId(), qa.getTitle(),

--- a/src/main/java/LinkerBell/campus_market_spring/dto/QaSearchResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/dto/QaSearchResponseDto.java
@@ -5,16 +5,24 @@ import LinkerBell.campus_market_spring.domain.QaCategory;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record QaSearchResponseDto(
-    Long qaId,
-    Long userId,
-    QaCategory category,
-    String title,
-    @JsonProperty(value = "isCompleted") Boolean isCompleted,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime answerDate,
-    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") LocalDateTime createdDate
-) {
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class QaSearchResponseDto {
+
+    private Long qaId;
+    private Long userId;
+    private QaCategory category;
+    private String title;
+    @JsonProperty(value = "isCompleted") private Boolean isCompleted;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") private LocalDateTime answerDate;
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss") private LocalDateTime createdDate;
 
     public QaSearchResponseDto(QA qa) {
         this(qa.getQaId(), qa.getUser().getUserId(),

--- a/src/main/java/LinkerBell/campus_market_spring/dto/UserReportCategoryResponseDto.java
+++ b/src/main/java/LinkerBell/campus_market_spring/dto/UserReportCategoryResponseDto.java
@@ -2,8 +2,16 @@ package LinkerBell.campus_market_spring.dto;
 
 import LinkerBell.campus_market_spring.domain.UserReportCategory;
 import java.io.Serializable;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-public record UserReportCategoryResponseDto(UserReportCategory[] categories) implements
-    Serializable {
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+public class UserReportCategoryResponseDto {
 
+    private UserReportCategory[] categories;
 }

--- a/src/main/java/LinkerBell/campus_market_spring/global/config/FirebaseConfig.java
+++ b/src/main/java/LinkerBell/campus_market_spring/global/config/FirebaseConfig.java
@@ -23,7 +23,7 @@ public class FirebaseConfig {
     public void init() {
         try {
             InputStream serviceAccount = new FileInputStream(firebasePath);
-            FirebaseOptions options = new FirebaseOptions.Builder()
+            FirebaseOptions options = FirebaseOptions.builder()
                 .setCredentials(GoogleCredentials.fromStream(serviceAccount))
                 .build();
 

--- a/src/test/java/LinkerBell/campus_market_spring/admin/service/AdminServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/admin/service/AdminServiceTest.java
@@ -120,17 +120,21 @@ class AdminServiceTest {
         User user = createUser(100L);
         User target = createUser(101L);
         UserReport userReport = createUserReport(user, target, 1L);
+        boolean isSuspended = true;
+        int suspendPeriod = 5;
+        String suspendReason = "test Reason";
 
         given(userReportRepository.findById(anyLong())).willReturn(Optional.ofNullable(userReport));
         given(blacklistRepository.findByUser(any(User.class))).willReturn(Optional.empty());
 
         // when
-        adminService.receiveUserReport(userReport.getUserReportId(), true, "test Reason", 5);
+        adminService.receiveUserReport(userReport.getUserReportId(), isSuspended, suspendReason, suspendPeriod);
 
         // then
         then(blacklistRepository).should(times(1)).save(assertArg(b -> {
             assertThat(b).isNotNull();
             assertThat(b.getEndDate()).isAfter(LocalDateTime.now());
+            assertThat(b.getReason()).isEqualTo(suspendReason);
         }));
     }
 

--- a/src/test/java/LinkerBell/campus_market_spring/repository/ItemRepositoryTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/repository/ItemRepositoryTest.java
@@ -999,9 +999,9 @@ class ItemRepositoryTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.getContent().size()).isEqualTo(items.size());
-        assertThat(response.getContent().get(0).itemId())
+        assertThat(response.getContent().get(0).getItemId())
             .isEqualTo(items.get(items.size() - 1).getItemId());
-        assertThat(response.getContent().get(0).universityName())
+        assertThat(response.getContent().get(0).getUniversityName())
             .isEqualTo(items.get(items.size() - 1).getCampus().getUniversityName());
     }
 
@@ -1029,14 +1029,14 @@ class ItemRepositoryTest {
         assertThat(response).isNotNull();
         assertThat(response.getContent().size()).isEqualTo(5);
 
-        assertThat(response.getContent().get(0).itemId())
+        assertThat(response.getContent().get(0).getItemId())
             .isEqualTo(items.get(4).getItemId());
-        assertThat(response.getContent().get(0).universityName())
+        assertThat(response.getContent().get(0).getUniversityName())
             .isEqualTo(items.get(4).getCampus().getUniversityName());
 
-        assertThat(response.getContent().get(1).itemId())
+        assertThat(response.getContent().get(1).getItemId())
             .isEqualTo(items.get(3).getItemId());
-        assertThat(response.getContent().get(1).universityName())
+        assertThat(response.getContent().get(1).getUniversityName())
             .isEqualTo(items.get(3).getCampus().getUniversityName());
     }
 
@@ -1077,13 +1077,13 @@ class ItemRepositoryTest {
         assertThat(response).isNotNull();
         assertThat(response.getContent().size()).isEqualTo(5);
 
-        assertThat(response.getContent().get(0).itemId())
+        assertThat(response.getContent().get(0).getItemId())
             .isEqualTo(items.get(29).getItemId());
-        assertThat(response.getContent().get(0).isDeleted()).isTrue();
+        assertThat(response.getContent().get(0).getIsDeleted()).isTrue();
 
-        assertThat(response.getContent().get(1).itemId())
+        assertThat(response.getContent().get(1).getItemId())
             .isEqualTo(items.get(28).getItemId());
-        assertThat(response.getContent().get(1).isDeleted()).isTrue();
+        assertThat(response.getContent().get(1).getIsDeleted()).isTrue();
     }
 
     private void updateItemPhotos(List<ItemPhotos> existingItemPhotos,

--- a/src/test/java/LinkerBell/campus_market_spring/service/QaServiceTest.java
+++ b/src/test/java/LinkerBell/campus_market_spring/service/QaServiceTest.java
@@ -69,8 +69,8 @@ class QaServiceTest {
 
         // then
         assertThat(response).isNotNull();
-        assertThat(response.userId()).isEqualTo(qa.getQaId());
-        assertThat(response.answerDescription()).isEqualTo(qa.getAnswerDescription());
+        assertThat(response.getUserId()).isEqualTo(qa.getQaId());
+        assertThat(response.getAnswerDescription()).isEqualTo(qa.getAnswerDescription());
     }
 
     @Test


### PR DESCRIPTION
### 관리자용 문의 및 사용자 신고 상세 내용 정보 추가
- 문의 += 답변 내용, 답변 날짜
- 사용자 신고 += 정지 여부, 정지 사유, 정지 기간
- 사용자 신고 엔티티 += 정지 여부, 정지 사유, 정지 기간

### record -> class dto로 수정